### PR TITLE
Update to sampler and agent representation to facilitate adversarial RL algorithm development

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,13 @@ Supports CPU and GPU computation and implements the following algorithms:
 * <a href="./src/model_free/il/sqil.jl">(SQIL)</a>
 * <a href="./src/model_free/il/asaf.jl">Adversarial Soft Advantage Fitting (ASAF)</a>
 
+### Batch RL
+* <a href="./src/model_free/batch/sac.jl">Batch Soft Actor Critic (SAC)</a>
+* <a href="./src/model_free/batch/cql.jl">Conservative Q-Learning (CQL)</a>
 
-Note for imitation learning algorithms: The parameter `normalize_demo::Bool` determines if the provided expert demonstrations should be normalized by the state and action spaces provided to the solver.
+### Adversarial RL
+* <a href="./src/model_free/adversarial/rarl.jl">Robust Adversarial RL (RARL)</a>
+
 
 ## Installation
 

--- a/examples/adversarial/cartpole.jl
+++ b/examples/adversarial/cartpole.jl
@@ -1,0 +1,89 @@
+using POMDPs, Crux, Flux, POMDPGym, Random, Distributions, POMDPPolicies
+Crux.set_function("isfailure", POMDPGym.isfailure)
+
+px = MvNormal2([0f0], [0.5f0])
+
+# Construct the MDP
+mdp = AdditiveAdversarialMDP(CartPoleMDP(), px)
+S = state_space(mdp)
+N = 100000
+
+# construct the model 
+QSA() = ContinuousNetwork(Chain(Dense(6, 64, relu), Dense(64, 64, relu), Dense(64, 1)))
+Pf() = ContinuousNetwork(Chain(Dense(6, 64, relu), Dense(64, 64, relu), Dense(64, 1, (x)-> -softplus(-(x-2)))))
+A() = ContinuousNetwork(Chain(Dense(5, 64, relu), Dense(64, 64, relu), Dense(64, 1, tanh), x -> 2f0 * x), 1)
+
+function G()
+    base = Chain(Dense(5, 64, relu), Dense(64, 64, relu))
+    mu = ContinuousNetwork(Chain(base..., Dense(64, 1)))
+    logΣ = ContinuousNetwork(Chain(base..., Dense(64, 1), x->x .+1f0), 1)
+    GaussianPolicy2(mu, logΣ, true)
+end
+
+
+Protag() = ActorCritic(A(), DoubleNetwork(QSA(), QSA()))
+Antag() = ActorCritic(G(), Pf())
+
+AdvPol(p = Protag()) = AdversarialPolicy(p, Antag())
+
+𝒮_td3 = TD3(;π=Protag(), S=S, N=50000, buffer_size=Int(1e5), buffer_init=1000)
+π_td3 = solve(𝒮_td3, mdp)
+
+
+# solve with IS
+𝒮_isarl = ISARL_Continuous(π=AdvPol(), 
+                           S=S,
+                           N=100000,
+                           px=px, 
+                           buffer_size=Int(1e5), 
+                           buffer_init=1000,
+                           max_steps=1000,
+                           desired_AP_ratio=1.0)
+π_isarl = solve(𝒮_isarl, mdp)
+
+# check the number of failures in the buffers (compared to successs)
+sum(𝒮_isarl.buffer[:fail])
+sum(𝒮_isarl.buffer[:done])
+
+
+
+# Plot the distribution of disturbances
+using Plots
+histogram(𝒮_isarl.buffer[:x][:])
+
+# Plot the value function in 2D
+v(θ, t) = sum(value(antagonist(𝒮_isarl.π), [θ, -1, t, 0]))
+heatmap(deg2rad(-25):0.01:deg2rad(25), 0:0.1:5, v)
+
+# Show the distribution of data in the replay buffer
+scatter(𝒮_isarl.buffer[:s][1, :], 𝒮_isarl.buffer[:s][3, :], marker_z = 𝒮_isarl.buffer[:done][1,:], xlabel="θ", ylabel="t", alpha=0.5)
+vline!([deg2rad(20), deg2rad(-20)])
+
+
+
+# Solve with DQN
+𝒮_dqn = DQN(π=QS(as), S=S, N=N)
+π_dqn = solve(𝒮_dqn, mdp)
+
+
+
+# solve with RARL
+𝒮_rarl = RARL(π=AdvPol(), S=S, N=N)
+π_rarl = solve(𝒮_rarl, mdp)
+
+pfail_rarl = Crux.failure(Sampler(mdp, protagonist(π_rarl), S=S, max_steps=100), Neps=Int(1e5), threshold=100)
+println("RARL Failure rate: ", pfail_rarl)
+
+
+pfail_isarl = Crux.failure(Sampler(mdp, protagonist(π_isarl), S=S, max_steps=100), Neps=Int(1e5), threshold=100)
+println("IS Failure rate: ", pfail_isarl)
+
+pol = AdvPol()
+
+𝒮_isarl.buffer
+
+
+pol = AdversarialPolicy(π_dqn, Pf(xs), ϵGreedyPolicy(Crux.LinearDecaySchedule(1., 0.1, floor(Int, N/2)), xs))
+𝒮_isarl = ISARL_Discrete(π=pol, S=S, N=N, xlogprobs=xlogprobs)
+π_isarl = solve(𝒮_isarl, mdp)
+

--- a/examples/adversarial/collision_avoidance.jl
+++ b/examples/adversarial/collision_avoidance.jl
@@ -1,0 +1,77 @@
+using Crux, POMDPGym, POMDPs, POMDPPolicies, Flux, Random, BSON
+using LocalApproximationValueIteration, GridInterpolations, LocalFunctionApproximation
+Crux.set_function("isfailure", POMDPGym.isfailure)
+
+# Creat the mdp
+mdp = CollisionAvoidanceMDP()
+S = state_space(mdp, μ=[0f0, 0f0, 0f0, 20f0], σ = [200f0, 10f0, 5f0, 20f0])
+
+# Function to evaluate the policy
+function evaluate_policy(pol; Neps = Int(1e5), S = state_space(mdp))
+    s = Sampler(mdp, pol, A = DiscreteSpace(actions(mdp)), required_columns=[:fail, :x], S=S)
+    D = episodes!(s, Neps=Neps)
+    fail_rate = sum(D[:fail]) / Neps
+    alert_rate = sum(D[:r] .== -1.0) / Neps
+    println("fail_rate: $fail_rate, alert_rate: $alert_rate")
+    return fail_rate, alert_rate
+end
+
+
+results = []
+
+for i=1:5
+    Random.seed!(i)
+
+
+    # DQN_params
+    N = 100000
+    π_explore(outputs) = ϵGreedyPolicy(Crux.LinearDecaySchedule(1.0, 0.1, floor(Int, N/2)), outputs)
+    DQN_params() = (S=S, 
+                    N=N, 
+                    buffer_size=Int(1e5), 
+                    buffer_init=1000, 
+                    π_explore=π_explore(actions(mdp)), 
+                    c_opt=(;batch_size=256, optimizer=ADAM(1e-4)))
+    ARL_params() = (DQN_params()..., 
+                    x_c_opt=(;batch_size=256, optimizer=ADAM(1e-4)), 
+                    desired_AP_ratio=3)
+    neg_QS(outputs) = DiscreteNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, length(outputs), x->-softplus(-x))), outputs)
+    QS(outputs) = DiscreteNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu),Dense(64, length(outputs))), outputs)
+    (;batch_size=256, optimizer=ADAM(1e-4))
+
+    # Train with DQN
+    𝒮_dqn = DQN(π=neg_QS(actions(mdp)); DQN_params()...)
+    π_dqn = solve(𝒮_dqn, mdp)
+
+    # Train with ISARL
+    # Pf(outputs) = DiscreteNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, length(outputs), (x) -> softplus(x))), outputs, (x) -> (mdp.px.p .* (x .+ 1f-3)) ./ sum(mdp.px.p .* (x .+ 1f-3), dims=1), true)
+    Pf(outputs) = DiscreteNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, length(outputs), (x) -> -softplus(-(x-2)))), outputs, (x) -> (mdp.px.p .* softmax(x)) ./ sum(mdp.px.p .* softmax(x), dims=1), true)
+    xlogprobs = Float32.(log.(mdp.px.p))
+    𝒮_isarl = Crux.ISARL_Discrete(;π=AdversarialPolicy(neg_QS(actions(mdp)), Pf(disturbances(mdp))), ARL_params()..., px=mdp.px, xlogprobs=xlogprobs)
+    π_isarl = solve(𝒮_isarl, mdp)
+
+    # Train with RARL
+    𝒮_rarl = RARL_Discrete(;π=AdversarialPolicy(neg_QS(actions(mdp)), QS(disturbances(mdp)), π_explore(disturbances(mdp))), ARL_params()...)
+    π_rarl = solve(𝒮_rarl, mdp)
+
+    # Evaluate all of the policies
+    Neval = Int(1e5)
+    dqn_fr, dqn_ar = evaluate_policy(π_dqn, Neps = Neval, S=S)
+    isarl_fr, isarl_ar = evaluate_policy(protagonist(𝒮_isarl.π), Neps = Neval, S=S)
+    rarl_fr, rarl_ar = evaluate_policy(protagonist(𝒮_rarl.π), Neps = Neval, S=S)
+
+    push!(results, (;dqn_fr, dqn_ar, isarl_fr, isarl_ar, rarl_fr, rarl_ar))
+end
+BSON.@save "collision_avoidance_results.bson" results
+
+results
+
+# No policy at all
+no_alert_pol = FunctionPolicy((s)->0f0)
+
+# Optimal policy with dynamic programming
+opt_pol = OptimalCollisionAvoidancePolicy(mdp)
+
+evaluate_policy(opt_pol, Neps = Int(1e4))
+evaluate_policy(no_alert_pol, Neps = Int(1e4))
+

--- a/examples/adversarial/continuous_bandit.jl
+++ b/examples/adversarial/continuous_bandit.jl
@@ -1,0 +1,48 @@
+using POMDPs, Crux, Flux, POMDPGym, Random, Distributions, POMDPPolicies
+Crux.set_function("isfailure", POMDPGym.isfailure)
+
+# Define the disturbance distribution based on a normal distribution
+px = MvNormal2([0f0], [0.5f0])
+
+# Construct the MDP
+mdp = AdditiveAdversarialMDP(ContinuousBanditMDP(), px)
+S = state_space(mdp)
+N = 10000
+
+# construct the model 
+QSA() = ContinuousNetwork(Chain(Dense(2, 64, relu), Dense(64, 64, relu), Dense(64, 1)))
+Pf() = ContinuousNetwork(Chain(Dense(2, 64, relu), Dense(64, 64, relu), Dense(64, 1, sigmoid)))
+A() = ContinuousNetwork(Chain(Dense(1, 64, relu), Dense(64, 64, relu), Dense(64, 1, tanh), x -> 2f0 * x), 1)
+
+G() = GaussianPolicy(A(), zeros(Float32, 1))
+
+Protag() = ActorCritic(A(), DoubleNetwork(QSA(), QSA()))
+Antag() = ActorCritic(G(), Pf())
+
+AdvPol(p = Protag()) = AdversarialPolicy(p, Antag())
+
+𝒮_td3 = TD3(;π=ActorCritic(A(), DoubleNetwork(QSA(), QSA())), S=S, N=50000, buffer_size=Int(1e5), buffer_init=1000)
+π_td3 = solve(𝒮_td3, mdp)
+
+
+# solve with IS
+𝒮_isarl = ISARL_Continuous(π=AdvPol(), 
+                           S=S, 
+                           N=50000, 
+                           π_explore=GaussianNoiseExplorationPolicy(Crux.LinearDecaySchedule(0., 0.0, floor(Int, 15000))),
+                           px=px, 
+                           return_at_episode_end=false,
+                           buffer_size=Int(1e5), 
+                           buffer_init=1000,)
+ 
+π_isarl = solve(𝒮_isarl, mdp)
+
+
+plot(-3:0.1:3, [value(antagonist(𝒮_isarl.π), [0], [i])[1] for i=-3:0.1:3], label="Probability of failure")
+
+plot!(-3:0.1:3, [exp(logpdf(antagonist(𝒮_isarl.π).A, [0], [i])[1]) for i=-3:0.1:3], label="Failure Policy")
+
+plot!(-3:0.1:3, [exp.(logpdf(px, i))[1] for i=-3:0.1:3], label="Px")
+
+logpdf(px, 0.1)
+

--- a/examples/adversarial/continuous_pendulum.jl
+++ b/examples/adversarial/continuous_pendulum.jl
@@ -1,0 +1,93 @@
+using POMDPs, Crux, Flux, POMDPGym, Random, Distributions, POMDPPolicies, Plots
+Crux.set_function("isfailure", POMDPGym.isfailure)
+
+# Define the disturbance distribution based on a normal distribution
+px =MvNormal2([0f0], [0.5f0])
+
+# Construct the MDP
+mdp = AdditiveAdversarialMDP(InvertedPendulumMDP(λcost=0, include_time_in_state=true), px)
+S = state_space(mdp)
+N = 100000
+
+# construct the model 
+QSA() = ContinuousNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, 1)))
+Pf() = ContinuousNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, 1, sigmoid)))
+A() = ContinuousNetwork(Chain(Dense(3, 64, relu), Dense(64, 64, relu), Dense(64, 1, tanh), x -> 2f0 * x), 1)
+
+function G()
+    base = Chain(Dense(3, 64, relu), Dense(64, 64, relu))
+    mu = ContinuousNetwork(Chain(base..., Dense(64, 1)))
+    logΣ = ContinuousNetwork(Chain(base..., Dense(64, 1)), 1)
+    GaussianPolicy2(mu, logΣ, true)
+end
+
+Protag() = ActorCritic(A(), DoubleNetwork(QSA(), QSA()))
+Antag() = ActorCritic(G(), Pf())
+
+AdvPol(p = Protag()) = AdversarialPolicy(p, Antag())
+
+𝒮_td3 = TD3(;π=ActorCritic(A(), DoubleNetwork(QSA(), QSA())), S=S, N=50000, buffer_size=Int(1e5), buffer_init=1000)
+π_td3 = solve(𝒮_td3, mdp)
+
+
+# solve with IS
+𝒮_isarl = ISARL_Continuous(π=AdvPol(), 
+                           S=S, 
+                           N=100000,
+                           px=px,
+                           buffer_size=Int(1e5), 
+                           buffer_init=1000,
+                           desired_AP_ratio=1)
+π_isarl = solve(𝒮_isarl, mdp)
+
+
+# check the number of failures in the buffers (compared to successs)
+sum(𝒮_isarl.buffer[:fail])
+sum(𝒮_isarl.buffer[:done])
+
+
+
+
+# Plot the distribution of disturbances
+histogram(𝒮_isarl.buffer[:x][:])
+
+# Plot the value function in 2D
+v(θ, t) = value(antagonist(𝒮_isarl.π), [θ, 0, t, 0])[1]
+heatmap(deg2rad(-25):0.01:deg2rad(25), 0:0.1:5, v)
+
+# Show the distribution of data in the replay buffer
+scatter(𝒮_isarl.buffer[:s][1, :], 𝒮_isarl.buffer[:s][3, :], marker_z = 𝒮_isarl.buffer[:done][1,:], xlabel="θ", ylabel="t", alpha=0.5)
+vline!([deg2rad(20), deg2rad(-20)])
+
+plot(-3:0.1:3, [exp.(logpdf(antagonist(𝒮_isarl.π).A, [0, 0, 0], [x]))[1] for x=-3:0.1:3], label="Px")
+
+antagonist(𝒮_isarl.π).A.logΣ([0, 0, 0])
+, [1])[1]
+
+# Solve with DQN
+𝒮_dqn = DQN(π=QS(as), S=S, N=N)
+π_dqn = solve(𝒮_dqn, mdp)
+
+pfail_dqn = Crux.failure(Sampler(mdp, π_dqn, S=S, max_steps=100), Neps=Int(1e3), threshold=100)
+println("DQN Failure rate: ", pfail_dqn)
+
+# solve with RARL
+𝒮_rarl = RARL(π=AdvPol(), S=S, N=N)
+π_rarl = solve(𝒮_rarl, mdp)
+
+pfail_rarl = Crux.failure(Sampler(mdp, protagonist(π_rarl), S=S, max_steps=100), Neps=Int(1e5), threshold=100)
+println("RARL Failure rate: ", pfail_rarl)
+
+
+pfail_isarl = Crux.failure(Sampler(mdp, protagonist(π_isarl), S=S, max_steps=100), Neps=Int(1e5), threshold=100)
+println("IS Failure rate: ", pfail_isarl)
+
+pol = AdvPol()
+
+𝒮_isarl.buffer
+
+
+pol = AdversarialPolicy(π_dqn, Pf(xs), ϵGreedyPolicy(Crux.LinearDecaySchedule(1., 0.1, floor(Int, N/2)), xs))
+𝒮_isarl = ISARL_Discrete(π=pol, S=S, N=N, xlogprobs=xlogprobs)
+π_isarl = solve(𝒮_isarl, mdp)
+

--- a/examples/adversarial/continuumworld.jl
+++ b/examples/adversarial/continuumworld.jl
@@ -1,0 +1,90 @@
+using POMDPs, Crux, Flux, POMDPGym, Random, Distributions, POMDPPolicies
+Crux.set_function("isfailure", POMDPGym.isfailure)
+
+struct MvNormal2
+    μ
+    logσ
+    μ_gpu
+    logσ_gpu
+    d
+    MvNormal2(μ, σ) = new(μ, Base.log.(σ), μ|>gpu, Base.log.(σ)|>gpu, MvNormal(cpu(μ), cpu(σ)))
+end
+
+function Base.rand(d::MvNormal2, sz::Int...) 
+    r = rand(d.d, sz...)  
+    if length(r) == 1
+        return r[1]
+    end
+    r
+end
+
+function Distributions.logpdf(d::MvNormal2, x)
+    if device(x)==gpu
+        Crux.gaussian_logpdf(d.μ_gpu, d.logσ_gpu, x)
+    else
+        Crux.gaussian_logpdf(d.μ, d.logσ, x)
+    end
+end
+        
+
+# Define the disturbance distribution based on a normal distribution
+px = MvNormal2([0f0, 0f0], [0.2f0, 0.2f0])
+
+# Construct the MDP
+function build_mdp()
+    Random.seed!(1)
+    rp() = rand(Uniform(-1, 1))
+    rad() = abs(rand(Uniform(0.05, 0.15)))
+
+    failures = Dict(Circle(Vec2(rp(),rp()), rad())=>-0.01f0 for i=1:1)
+    rewards = Dict(failures..., Circle(Vec2(-0.5f0,0.5f0), 0.2f0)=>0.9f0)
+    mdp = AdditiveAdversarialMDP(ContinuumWorldMDP(rewards=rewards, vel_thresh=1f0, discount=1.0), px)
+end
+mdp = build_mdp()
+render(mdp)
+S = state_space(mdp)
+
+# construct the models for the protagonist
+QSA() = ContinuousNetwork(Chain(Dense(S.dims[1] + 2, 128, relu), Dense(128, 128, relu), Dense(128, 1)))
+A() = ContinuousNetwork(Chain(Dense(S.dims[1], 128, relu), Dense(128, 128, relu), Dense(128, 2, tanh)))
+Protag() = ActorCritic(A(), DoubleNetwork(QSA(), QSA()))
+
+# And the models for the antagonist
+Pf() = ContinuousNetwork(Chain(Dense(S.dims[1] + 2, 128, relu), Dense(128, 128, relu), Dense(128, 1, sigmoid)))
+function G()
+    base = Chain(Dense(S.dims[1], 128, relu), Dense(128, 128, relu))
+    mu = ContinuousNetwork(Chain(base..., Dense(128, 2)))
+    logΣ = ContinuousNetwork(Chain(base..., Dense(128, 2)))
+    GaussianPolicy2(mu, logΣ, true)
+end
+Antag() = ActorCritic(G(), Pf())
+
+# Solve with a traditional RL approach
+TD3_params() = (N=100000, S=S, buffer_size=Int(1e5), buffer_init=1000)
+
+𝒮_td3 = TD3(;π=ActorCritic(A(), DoubleNetwork(QSA(), QSA())), TD3_params()...)
+π_td3 = solve(𝒮_td3, mdp)
+
+# Solver with adversarial approach
+ARL_params() = (TD3_params()..., desired_AP_ratio=1.0)
+
+# solve with IS
+𝒮_isarl = ISARL_Continuous(;π=AdversarialPolicy(π_td3, Antag()) |> gpu, ARL_params()..., px)
+π_isarl = solve(𝒮_isarl, mdp)
+
+# solve with RARL
+𝒮_rarl = Crux.RARL_Continuous(;π=AdversarialPolicy(Protag(), Protag(), GaussianNoiseExplorationPolicy(0.2f0)) |>gpu, ARL_params()...)
+π_rarl = solve(𝒮_rarl, mdp)
+
+Dvanilla = steps!(Sampler(mdp, π_td3, S=S, required_columns=[:fail]), Nsteps=10000)
+sum(Dvanilla[:fail])
+
+Disarl = steps!(Sampler(mdp, protagonist(π_isarl), S=S, required_columns=[:fail]), Nsteps=10000)
+sum(Disarl[:fail])
+
+Drarl = steps!(Sampler(mdp, protagonist(π_rarl), S=S, required_columns=[:fail]), Nsteps=10000)
+sum(Drarl[:fail])
+
+gif(mdp, protagonist(π_isarl), "isarl.gif", Neps=10)
+gif(mdp, π_td3, "td3.gif", Neps=100)
+

--- a/examples/adversarial/discrete_pendulum.jl
+++ b/examples/adversarial/discrete_pendulum.jl
@@ -1,0 +1,89 @@
+using POMDPs, Crux, Flux, POMDPGym, Random, Distributions, POMDPPolicies, Plots
+Crux.set_function("isfailure", POMDPGym.isfailure)
+
+# Define the disturbance distribution based on a normal distribution
+xnom = Normal(0f0, 0.5f0)
+xs = Float32[-2., -0.5, 0, 0.5, 2.]
+ps = exp.([logpdf(xnom, x) for x in xs])
+ps ./= sum(ps)
+px = DiscreteNonParametric(xs, ps)
+xlogprobs = Base.log.(ps)
+
+# Action space of the protagonist
+as = Float32[-2., -0.5, 0, 0.5, 2.]
+
+# Construct the MDP
+mdp = AdditiveAdversarialMDP(InvertedPendulumMDP(actions=as, λcost=0, include_time_in_state=true), px)
+S = state_space(mdp)
+
+# construct the model 
+QS(outputs) = DiscreteNetwork(Chain(Dense(3, 64, relu), Dense(64, 64, relu), Dense(64, length(outputs))), outputs)
+Pf(outputs) = DiscreteNetwork(Chain(Dense(3, 64, relu), Dense(64, 64, relu), Dense(64, length(outputs), (x)->-softplus(-(x-2)))), outputs)
+# Pf(outputs) = DiscreteNetwork(Chain(Dense(3, 256, tanh), Dense(256, 256, tanh), Dense(256, length(outputs), sigmoid)), outputs, (x) -> x ./ sum(x, dims=1))
+AdvPol(protag = QS(as)) = AdversarialPolicy(protag, Pf(xs))
+
+# Solve with DQN
+𝒮_dqn = DQN(π=QS(as), S=S, N=50000, buffer_size=Int(1e4), buffer_init=1000, required_columns=[:fail])
+π_dqn = solve(𝒮_dqn, mdp)
+
+# show the nominal distriubtion of paths
+D = steps!(Sampler(mdp, 𝒮_isarl.π.P, S=S, required_columns=[:fail]), Nsteps=10000)
+D2 = steps!(Sampler(mdp, π_dqn, S=S, required_columns=[:fail]), Nsteps=10000)
+scatter(D[:s][1, :], D[:s][3, :], marker_z = D[:done][1,:], xlabel="θ", ylabel="t", alpha=0.5)
+scatter(D2[:s][1, :], D2[:s][3, :], marker_z = D2[:done][1,:], xlabel="θ", ylabel="t", alpha=0.5)
+
+# solve with IS
+𝒮_isarl = ISARL_Discrete(π=AdvPol(), 
+                         S=S, 
+                         ϵ_init = 1e-5,
+                         N=100000, 
+                         xlogprobs=xlogprobs, 
+                         px=px, 
+                         buffer_size=100_000,
+                         buffer_init=1000, 
+                         c_opt = (;batch_size=128),
+                         x_c_opt=(;batch_size=1024), 
+                         π_explore=ϵGreedyPolicy(Crux.LinearDecaySchedule(1f0, 0.1f0, 20000), as),
+                         )
+π_isarl = solve(𝒮_isarl, mdp)
+
+y = Crux.IS_DQN_target(antagonist(𝒮_isarl.π),𝒮_isarl.𝒫, 𝒮_isarl.buffer, 1f0)
+
+indices = 𝒮_isarl.buffer[:done][:]
+y[indices]
+
+value(antagonist(𝒮_isarl.π), 𝒮_isarl.buffer[:s][:,indices], 𝒮_isarl.buffer[:x][:,indices])
+
+
+# check the number of failures in the buffers (compared to successs)
+sum(𝒮_isarl.buffer[:fail])
+sum(𝒮_isarl.buffer[:done])
+
+# Plot the distribution of disturbances
+histogram(Flux.onecold(𝒮_isarl.buffer[:x]))
+
+# Plot the value function in 2D
+v(θ, t) = sum(ps .* value(antagonist(𝒮_isarl.π), [θ, -1, t]))
+heatmap(deg2rad(-20):0.01:deg2rad(20), 0:0.1:5, v)
+
+# Show the distribution of data in the replay buffer
+scatter(𝒮_isarl.buffer[:s][1, :], 𝒮_isarl.buffer[:s][3, :], marker_z = 𝒮_isarl.buffer[:done][1,:], xlabel="θ", ylabel="t", alpha=0.5)
+vline!([deg2rad(20), deg2rad(-20)])
+
+
+# pfail_dqn = Crux.failure(Sampler(mdp, π_dqn, S=S, max_steps=100), Neps=Int(1e5), threshold=100)
+# println("DQN Failure rate: ", pfail_dqn)
+
+# solve with RARL
+# 𝒮_rarl = RARL(π=AdvPol(), S=S, N=N)
+# π_rarl = solve(𝒮_rarl, mdp)
+
+# pfail_rarl = Crux.failure(Sampler(mdp, protagonist(π_rarl), S=S, max_steps=100), Neps=Int(1e5), threshold=100)
+# println("RARL Failure rate: ", pfail_rarl)
+
+
+
+# pfail_isarl = Crux.failure(Sampler(mdp, protagonist(π_isarl), S=S, max_steps=100), Neps=Int(1e5), threshold=100)
+# println("IS Failure rate: ", pfail_isarl)
+
+

--- a/examples/adversarial/pendulum.jl
+++ b/examples/adversarial/pendulum.jl
@@ -1,9 +1,0 @@
-using POMDPs, Crux, Flux, POMDPGym, Random, Distributions
-
-## Pendulum
-mdp = AdditiveAdversarialMDP(InvertedPendulumMDP(), Normal(0, 0.2))
-amin = [-2f0]
-amax = [2f0]
-rand_policy = FunctionPolicy((s) -> Float32.(rand.(Uniform.(amin, amax))))
-S = state_space(mdp, σ=[6.3f0, 8f0])
-

--- a/examples/adversarial/safety_gym.jl
+++ b/examples/adversarial/safety_gym.jl
@@ -1,0 +1,67 @@
+using POMDPs, Crux, Flux, POMDPGym, Random, Distributions, POMDPPolicies, PyCall
+init_mujoco_render() # Required for visualization
+pyimport("safety_gym")
+Crux.set_function("isfailure", POMDPGym.isfailure)
+
+# Define the disturbance distribution based on a normal distribution
+px = MvNormal([0f0, 0f0], [0.2f0, 0.2f0])
+
+# Construct the MDP
+mdp = AdditiveAdversarialPOMDP(EpisodicSafetyGym(pomdp=GymPOMDP(Symbol("Safexp-PointGoal1"), version=:v0), λ=0.01), px)
+mdp_nom = AdditiveAdversarialPOMDP(EpisodicSafetyGym(pomdp=GymPOMDP(Symbol("Safexp-PointGoal1"), version=:v0), λ=0.01), px)
+# mdp = AdditiveAdversarialPOMDP(GymPOMDP(Symbol("Safexp-PointGoal1"), version=:v0), px)
+S = state_space(mdp)
+
+# construct the models for the protagonist
+QSA() = ContinuousNetwork(Chain(Dense(62, 256, relu), Dense(256, 256, relu), Dense(256, 1)))
+A() = ContinuousNetwork(Chain(Dense(60, 256, relu), Dense(256, 256, relu), Dense(256, 2, tanh)))
+Protag() = ActorCritic(A(), DoubleNetwork(QSA(), QSA()))
+
+# And the models for the antagonist
+Pf() = ContinuousNetwork(Chain(Dense(62, 256, relu), Dense(256, 256, relu), Dense(256, 1, (x)-> -softplus(-(x-2)))))
+function SquashedG()
+    base = Chain(Dense(60, 256, relu), Dense(256, 256, relu))
+    mu = ContinuousNetwork(Chain(base..., Dense(256, 2)))
+    logΣ = ContinuousNetwork(Chain(base..., Dense(256, 2)))
+    SquashedGaussianPolicy(mu, logΣ)
+end
+Antag() = ActorCritic(SquashedG(), Pf())
+
+# Solve with a traditional RL approach
+TD3_params() = (N=100000, S=S, buffer_size=Int(1e5), buffer_init=1000, max_steps=1000)
+
+𝒮_td3 = TD3(;π=ActorCritic(A(), DoubleNetwork(QSA(), QSA())), TD3_params()...)
+π_td3 = solve(𝒮_td3, mdp)
+
+# Solver with adversarial approach
+ARL_params() = (TD3_params()..., desired_AP_ratio=1.0)
+
+# solve with IS
+𝒮_isarl = ISARL_Continuous(;π=AdversarialPolicy(Protag(), Antag()), ARL_params()..., px)
+π_isarl = solve(𝒮_isarl, mdp, mdp_nom)
+
+# solve with RARL
+𝒮_rarl = Crux.RARL_Continuous(;π=AdversarialPolicy(Protag(), Protag(), GaussianNoiseExplorationPolicy(0.2f0)), ARL_params()...)
+π_rarl = solve(𝒮_rarl, mdp, mdp_nom)
+
+
+
+D_vanilla = steps!(Sampler(mdp, π_td3, S=S, required_columns=[:cost], max_steps=1000), Nsteps=5000)
+sum(D_vanilla[:r])/5
+sum(D_vanilla[:cost])
+
+
+D_isarl = steps!(Sampler(mdp, protagonist(π_isarl), S=S, required_columns=[:cost], max_steps=1000), Nsteps=5000)
+sum(D_isarl[:r])/5
+sum(D_isarl[:cost])
+
+s = tovec(𝒮_isarl.buffer[:s][:, 100], S)
+antagonist(π_isarl).A.μ(s)
+exp.(antagonist(π_isarl).A.logΣ(s))
+
+using Plots
+histogram(𝒮_isarl.buffer[:x][:])
+
+
+
+

--- a/examples/rl/cartpole.jl
+++ b/examples/rl/cartpole.jl
@@ -22,6 +22,7 @@ V() = ContinuousNetwork(Chain(Dense(Crux.dim(S)..., 64, relu), Dense(64, 64, rel
 
 # Solve with DQN (~12 seconds)
 𝒮_dqn = DQN(π=A(), S=S, N=10000)
+𝒮_dqn.c_opt
 @time π_dqn = solve(𝒮_dqn, mdp)
 
 # Plot the learning curve

--- a/src/Crux.jl
+++ b/src/Crux.jl
@@ -23,28 +23,38 @@ module Crux
     using Statistics
     using Base.Iterators: partition
     
-    export ScalarParams, AbstractSpace, DiscreteSpace, ContinuousSpace, type, dim, 
-           state_space, device, cpucall, gpucall, mdcall, bslice, whiten, to2D, tovec
+    extra_functions = Dict()
+    function set_function(key, val)
+        extra_functions[key] = val
+    end
+    
+    export device, cpucall, gpucall, mdcall, bslice
+    include("devices.jl")
+    
+    export AbstractSpace, DiscreteSpace, ContinuousSpace, type, dim, state_space
+    include("spaces.jl")
+    
+    export ObjectCategorical, whiten, to2D, tovec, LinearDecaySchedule, MultitaskDecaySchedule
     include("utils.jl")
     
     export MinHeap, inverse_query, mdp_data, PriorityParams, ExperienceBuffer, buffer_like, minibatch,
            clear!, trim!, isprioritized, dim, episodes, update_priorities!, uniform_sample!, 
-           prioritized_sample!, capacity, normalize!, extra_columns
+           prioritized_sample!, capacity, normalize!, extra_columns, get_last_N_indices
     include("experience_buffer.jl")
     
     export TrainingParams, batch_train!
     include("training.jl")
     
-    export NetworkPolicy, polyak_average!, ContinuousNetwork, DiscreteNetwork, 
+    export PolicyParams, NetworkPolicy, polyak_average!, ContinuousNetwork, DiscreteNetwork, 
            DoubleNetwork, ActorCritic, GaussianPolicy, SquashedGaussianPolicy, 
-           DistributionPolicy, AdversarialPolicy, protagonist, antagonist,
-           GaussianNoiseExplorationPolicy, FirstExplorePolicy, ϵGreedyPolicy, LinearDecaySchedule,
+           DistributionPolicy, MixedPolicy, ϵGreedyPolicy,
+           GaussianNoiseExplorationPolicy, FirstExplorePolicy, 
            entropy, logpdf, action_space, exploration, layers, actor, critic
     include("policies.jl")
     
     export Sampler, initial_observation, terminate_episode!, step!, steps!, 
-           episodes!, fillto!, metric_by_key, metrics_by_key, undiscounted_return, discounted_return, failure, 
-           fill_gae!, fill_returns!, trime!
+           episodes!, fillto!, metric_by_key, metrics_by_key, undiscounted_return, 
+           discounted_return, failure, fill_gae!, fill_returns!, trim!
     include("sampler.jl")
     
     export elapsed, LoggerParams, aggregate_info, log_performance, 
@@ -75,7 +85,7 @@ module Crux
     export OrthogonalRegularizer
     include("extras/orthogonal_regularization.jl")
     
-    export MultitaskDecaySchedule, log_multitask_performances!, continual_learning
+    export log_multitask_performances!, continual_learning
     include("extras/multitask_learning.jl")
     
     export OnPolicySolver, OffPolicySolver, BatchSolver
@@ -109,9 +119,9 @@ module Crux
     include("model_free/batch/cql.jl")
     include("model_free/batch/sac.jl")
     
-    export AdversarialOffPolicySolver, RARL, ISARL
+    export AdversarialOffPolicySolver, RARL, RARL_DQN, RARL_TD3, ISARL, ISARL_DQN, ISARL_TD3
     include("model_free/adversarial/adv_off_policy.jl")
     include("model_free/adversarial/rarl.jl")
-    include("model_free/adversarial/is.jl")
+    include("model_free/adversarial/isarl.jl")
 end
 

--- a/src/Crux.jl
+++ b/src/Crux.jl
@@ -34,7 +34,8 @@ module Crux
     export AbstractSpace, DiscreteSpace, ContinuousSpace, type, dim, state_space
     include("spaces.jl")
     
-    export ObjectCategorical, whiten, to2D, tovec, LinearDecaySchedule, MultitaskDecaySchedule
+    export ObjectCategorical, ConstantLayer, whiten, to2D, tovec, 
+           LinearDecaySchedule, MultitaskDecaySchedule
     include("utils.jl")
     
     export MinHeap, inverse_query, mdp_data, PriorityParams, ExperienceBuffer, buffer_like, minibatch,

--- a/src/devices.jl
+++ b/src/devices.jl
@@ -1,0 +1,36 @@
+device(v::T) where T <: CuArray = gpu
+device(v::T) where T <: AbstractArray = cpu
+device(v::SubArray{T,N,P,I,L}) where {T, N, P <: CuArray, I, L} = gpu
+device(v::SubArray{T,N,P,I,L}) where {T, N, P <: AbstractArray, I, L} = cpu
+function device(c) 
+    p = Flux.params(c)
+    length(p) > 0 && p[1] isa CuArray ? gpu : cpu
+end 
+
+# Call F with input x but ensure they are both on the device of F
+gpucall(F, x::CuArray) = F(x)
+gpucall(F, x::SubArray{T,N,P,I,L}) where {T, N, P <: CuArray, I, L} = F(x)
+
+gpucall(F, x::Array) = cpu(F(gpu(x)))
+gpucall(F, x::SubArray{T,N,P,I,L}) where {T, N, P <: AbstractArray, I, L} = cpu(F(gpu(collect(x))))
+
+cpucall(F, x::Array) = F(x)
+cpucall(F, x::SubArray{T,N,P,I,L}) where {T, N, P <: AbstractArray, I, L} = F(x)
+
+cpucall(F, x::CuArray) = gpu(F(cpu(x)))
+cpucall(F, x::SubArray{T,N,P,I,L}) where {T, N, P <: CuArray, I, L} = gpu(F(cpu(x)))
+
+mdcall(F, x, device) = device == gpu ? gpucall(F,x) : cpucall(F, x)
+
+@inline function bslice(v, i)
+    nd = ndims(v)
+    if nd == 2
+        return view(v,:,i)
+    elseif nd == 3
+        return view(v, :, :, i)
+    elseif nd == 4
+        return view(v, :, :, :, i)
+    else
+        return view(v, ntuple(x->:, nd-1)..., i)
+    end
+end

--- a/src/experience_buffer.jl
+++ b/src/experience_buffer.jl
@@ -29,11 +29,11 @@ function mdp_data(S::T1, A::T2, capacity::Int, extras::Array{Symbol} = Symbol[];
         :done => ArrayType(fill(zero(D), 1, capacity))
         )
     for k in extras
-        if k in [:return, :logprob, :advantage, :cost]
+        if k in [:return, :logprob, :xlogprob, :advantage, :cost]
             data[k] = ArrayType(fill(zero(R), 1, capacity))
         elseif k in [:weight]
             data[k] = ArrayType(fill(one(R), 1, capacity))
-        elseif k in [:episode_end]
+        elseif k in [:episode_end, :fail]
             data[k] = ArrayType(fill(false, 1, capacity))
         elseif k in [:t, :i]
             data[k] = ArrayType(fill(0, 1, capacity))
@@ -197,6 +197,14 @@ function episodes(b::ExperienceBuffer)
         error("Need :episode_end flag or :t column to determine episodes")
     end
     zip(ep_starts, ep_ends)
+end
+
+function get_last_N_indices(b::ExperienceBuffer, N)
+    # Make sure we don't exceed the number of elements actually stored in the buffer
+    N = min(length(b), N)
+    C = capacity(b)
+    start_index = mod1(b.next_ind - N, C)
+    mod1.(start_index:start_index + N - 1, C)
 end
 
 # Note: data can be a dictionary or an experience buffer

--- a/src/extras/multitask_learning.jl
+++ b/src/extras/multitask_learning.jl
@@ -1,16 +1,6 @@
 POMDPs.discount(v::AbstractVector) = discount(v[1])
 
-function MultitaskDecaySchedule(steps::Int, task_ids; start = 1.0, stop = 0.1)
-    schedule = LinearDecaySchedule(start, stop, steps)
-    function val(i)
-        taskindex = ceil(Int, i / steps)
-        taskindex < 1 && return start
-        taskindex > length(task_ids) && return stop
-        taskid = task_ids[taskindex]
-        used_steps = steps*sum(task_ids[1:taskindex-1] .== taskid)
-        schedule(used_steps + mod1(i, steps))
-    end
-end
+
 
 function log_multitask_performances!(𝒮, tasks, logfn=log_undiscounted_return)
     push!(𝒮.log.extras, logfn([Sampler(t, 𝒮.π) for t in tasks]))

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -17,7 +17,7 @@ function Base.log(p::LoggerParams, i::Union{Int, UnitRange}, data...)
     !elapsed(i, p.period) && return
     i = i[end]
     p.verbose && print("Step: $i")
-    π_explore = (p.sampler isa Vector) ?  first(p.sampler).π_explore : p.sampler.π_explore
+    π_explore = (p.sampler isa Vector) ?  first(p.sampler).agent.π_explore : p.sampler.agent.π_explore
         
     for dict in [p.fns..., data..., log_exploration(π_explore)]
         d = dict isa Function ? dict(s=p.sampler, i=i) : dict

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -5,7 +5,7 @@ elapsed(i::UnitRange, N::Int) = any([i...] .% N .== 0)
     dir::String = "log/"
     period::Int64 = 500
     logger = TBLogger(dir, tb_increment)
-    fns = [log_undiscounted_return(10)]
+    fns = Any[log_undiscounted_return(10)]
     verbose::Bool = true
     sampler::Union{Sampler, Nothing, Vector} = nothing
 end
@@ -32,7 +32,11 @@ end
                         #t, solver.max_steps, nt[1], avg100_reward, loss_val, grad_val, scores_eval)
                         
 function aggregate_info(infos)
-    res = Dict(k => mean([info[k] for info in filter((x)->haskey(x, k), infos)]) for k in keys(infos[1]))
+    res = Dict()
+    for k in unique(vcat([collect(keys(info)) for info in infos]...))
+        res[k] = mean([info[k] for info in filter((x)->haskey(x, k), infos)])
+    end
+    res
 end
 
 # Built-in functions for logging common training things
@@ -55,7 +59,7 @@ end
 log_validation_error(loss, 𝒟_val; name="validation_error") = (;s, kwargs...) -> Dict(name => loss(s.π, 𝒟_val))
 
 log_exploration(policy) = (;kwargs...) -> Dict()
-log_exploration(policy::ϵGreedyPolicy; name = "eps") = (;i, kwargs...) -> Dict(name => policy.ϵ(i))
+log_exploration(policy::MixedPolicy; name = "eps") = (;i, kwargs...) -> Dict(name => policy.ϵ(i))
 log_exploration(policy::GaussianNoiseExplorationPolicy; name = "noise_std") = (;i, kwargs...) -> Dict(name => policy.σ(i))
 function log_exploration(policy::FirstExplorePolicy; name = "first_explore_on")
     (;i, kwargs...) -> begin

--- a/src/model_free/adversarial/adv_off_policy.jl
+++ b/src/model_free/adversarial/adv_off_policy.jl
@@ -1,117 +1,78 @@
 @with_kw mutable struct AdversarialOffPolicySolver <: Solver
-    π # Policy
-    S::AbstractSpace # State space
-    A::AbstractSpace = action_space(π) # Action space
-    N::Int = 1000 # Number of environment interactions
-    ΔN::Int = 4 # Number of interactions between updates
-    max_steps::Int = 100 # Maximum number of steps per episode
+    𝒮_pro::OffPolicySolver # Solver parameters for the protagonist
+    𝒮_ant::OffPolicySolver # Solver parameters for the antagonist
+    px::PolicyParams # Nominal disturbance policy
+    train_pro_every::Int = 1
+    train_ant_every::Int = 1
     log::Union{Nothing, LoggerParams} = nothing # The logging parameters
     i::Int = 0 # The current number of environment interactions
-    param_optimizers::Dict{Any, TrainingParams} = Dict() # Training parameters for the parameters
-    a_opt::Union{Nothing, TrainingParams} = nothing # Training parameters for the actor
-    c_opt::TrainingParams # Training parameters for the critic
-    x_param_optimizers::Dict{Any, TrainingParams} = Dict() # Training parameters for the parameters
-    x_a_opt::Union{Nothing, TrainingParams} = nothing # Training parameters for the actor
-    x_c_opt::TrainingParams # Training parameters for the critic
-    𝒫::NamedTuple = (;) # Parameters of the algorithm
-    desired_AP_ratio = 1 # Desired training ratio of protagonist to antagonist
-    
-    # Off-policy-specific parameters
-    π⁻ = deepcopy(π)
-    π_explore::Policy # exploration noise
-    target_update = (π⁻, π; kwargs...) -> polyak_average!(π⁻, π, 0.005f0) # Function for updating the target network
-    target_fn # Target for critic regression with input signature (π⁻, 𝒟, γ; i)
-    x_target_fn # Target for critic regression with input signature (π⁻, 𝒟, γ; i)
-    buffer_size = 1000 # Size of the buffer
-    required_columns = Symbol[]
-    buffer::ExperienceBuffer = ExperienceBuffer(S, A, buffer_size, required_columns) # The replay buffer
-    buffer_init::Int = max(c_opt.batch_size, 200) # Number of observations to initialize the buffer with
-    extra_buffers = [] # extra buffers (i.e. for experience replay in continual learning)
-    buffer_fractions = [1.0] # Fraction of the minibatch devoted to each buffer
 end
 
 function POMDPs.solve(𝒮::AdversarialOffPolicySolver, mdp)
-    # Construct the training buffer, constants, and sampler
-    𝒟 = buffer_like(𝒮.buffer, capacity=𝒮.c_opt.batch_size, device=device(𝒮.π))
+    # make some assertions on the parameters that should be shared
+    @assert 𝒮.𝒮_pro.buffer == 𝒮.𝒮_ant.buffer
+    @assert 𝒮.𝒮_pro.buffer_init == 𝒮.𝒮_ant.buffer_init
+    @assert 𝒮.𝒮_pro.required_columns == 𝒮.𝒮_ant.required_columns
+    @assert 𝒮.𝒮_pro.N == 𝒮.𝒮_ant.N
+    @assert 𝒮.𝒮_pro.S == 𝒮.𝒮_ant.S
+    @assert 𝒮.𝒮_pro.max_steps == 𝒮.𝒮_ant.max_steps
+    
+    # define shared parameters for easy reference
+    buffer = 𝒮.𝒮_pro.buffer
+    buffer_init = 𝒮.𝒮_pro.buffer_init
+    ΔN = 𝒮.𝒮_pro.ΔN + 𝒮.𝒮_ant.ΔN
+    N = 𝒮.𝒮_pro.N
+    S = 𝒮.𝒮_pro.S
+    max_steps = 𝒮.𝒮_pro.max_steps
+    
+    # Construct the training buffern for the protagonist and antagonist
+    𝒟_pro = buffer_like(buffer, capacity=𝒮.𝒮_protagonist.c_opt.batch_size, device=device(𝒮.𝒮_protagonist.π))
+    𝒟_ant = buffer_like(buffer, capacity=𝒮.𝒮_protagonist.c_opt.batch_size, device=device(𝒮.𝒮_protagonist.π))
+    
+    # Get the discount factor 
     γ = Float32(discount(mdp))
-    s = Sampler(mdp, 𝒮.π, S=𝒮.S, A=𝒮.A, max_steps=𝒮.max_steps, π_explore=𝒮.π_explore, required_columns=extra_columns(𝒮.buffer))
-    isnothing(𝒮.log.sampler) && (𝒮.log.sampler = s)
+    
+    # Two samplers, one for the traditional ap
+    s_pro = Sampler(mdp, 𝒮.𝒮_pro.agent, adversary=𝒮.px, S=S, max_steps=max_steps, required_columns=extra_columns(buffer))
+    s_ant = Sampler(mdp, 𝒮.𝒮_pro.agent, adversary=𝒮.𝒮_ant.agent, S=S, max_steps=max_steps, required_columns=extra_columns(buffer))
+    
+    s_nom = Sampler(mdp_nom, 𝒮.π, S=𝒮.S, A=𝒮.A, max_steps=𝒮.max_steps, required_columns=setdiff(extra_columns(𝒮.buffer), [:x]))
+    push!(𝒮.log.fns, (;kwargs...) -> Dict("nominal_undiscounted_return" => undiscounted_return(s_nom, Neps=10)))
+    
+    isnothing(𝒮.log.sampler) && (𝒮.log.sampler = s_pro)
 
     # Log the pre-train performance
     log(𝒮.log, 𝒮.i)
 
     # Fill the buffer with initial observations before training
-    𝒮.i += fillto!(𝒮.buffer, s, 𝒮.buffer_init, i=𝒮.i, explore=true)
-    
-    N_antagonist = 1
-    N_protagonist = 1
-    
-    antagonist_params = (antagonist(𝒮.π), antagonist(𝒮.π⁻), 𝒮.x_target_fn, 𝒮.x_param_optimizers, 𝒮.x_a_opt, 𝒮.x_c_opt)
-    protagonist_params = (protagonist(𝒮.π), protagonist(𝒮.π⁻), 𝒮.target_fn, 𝒮.param_optimizers, 𝒮.a_opt, 𝒮.c_opt)
+    𝒮.i += fillto!(buffer, s_pro, buffer_init, i=𝒮.i, explore=true)
+    𝒮.𝒮_pro.i = 𝒮.i
+    𝒮.𝒮_ant.i = 𝒮.i
     
     # Loop over the desired number of environment interactions
-    for 𝒮.i in range(𝒮.i, stop=𝒮.i + 𝒮.N - 𝒮.ΔN, step=𝒮.ΔN)
+    for 𝒮.i in range(𝒮.i, stop=𝒮.i + N - ΔN, step=ΔN)
+        # Update the per solver iteration
+        𝒮.𝒮_pro.i = 𝒮.i
+        𝒮.𝒮_ant.i = 𝒮.i
+        
         # Sample transitions into the replay buffer
-        push!(𝒮.buffer, steps!(s, Nsteps=𝒮.ΔN, explore=true, i=𝒮.i))
+        push!(buffer, steps!(s_pro, Nsteps=𝒮.𝒮_pro.ΔN, explore=true, i=𝒮.i))
+        push!(buffer, steps!(s_ant, Nsteps=𝒮.𝒮_ant.ΔN, explore=true, i=𝒮.i))
         
+        # callback for potentially updating the buffer
+        𝒮.post_experience_callback(buffer) 
+        
+        # Train the networks
         infos = []
-        
-        train_over = []
-        curr_ratio = N_antagonist / N_protagonist
-        if curr_ratio <= 𝒮.desired_AP_ratio
-            push!(train_over, antagonist_params)
-            N_antagonist += 1
-        end
-        if curr_ratio >= 𝒮.desired_AP_ratio
-            push!(train_over, protagonist_params)
-            N_protagonist += 1
-        end
-        
-        ## Loop over the antagonist and protagonist
-        for (π, π⁻, target_fn, param_optimizers, a_opt, c_opt) in train_over
-        
-            # Loop over the desired number of training steps
-            for epoch in 1:c_opt.epochs
-                # Sample a batch
-                rand!(𝒟, 𝒮.buffer, 𝒮.extra_buffers..., fracs=𝒮.buffer_fractions, i=𝒮.i)
-                
-                # initialize the info
-                info = Dict()
-                
-                # Compute the target
-                y = target_fn(π⁻, 𝒮.𝒫, 𝒟, γ, i=𝒮.i)
-                
-                # Train parameters
-                for (θs, p_opt) in param_optimizers
-                    train!(θs, (;kwargs...) -> p_opt.loss(π, 𝒮.𝒫, 𝒟; kwargs...), p_opt, info=info)
-                end
-                
-                # Train the critic
-                if ((epoch-1) % c_opt.update_every) == 0
-                    train!(critic(π), (;kwargs...) -> c_opt.loss(π, 𝒮.𝒫, 𝒟, y; weighted=ispri, kwargs...), c_opt, info=info)
-                end
-                
-                # Train the actor 
-                if !isnothing(a_opt) && ((epoch-1) % a_opt.update_every) == 0
-                    train!(actor(π), (;kwargs...) -> a_opt.loss(π, 𝒮.𝒫, 𝒟; kwargs...), a_opt, info=info)
-                
-                    # Update the target network
-                    𝒮.target_update(π⁻, π)
-                end
-                
-                # Store the training information
-                push!(infos, info)
-                
-            end
-            # If not using a separate actor, update target networks after critic training
-            isnothing(a_opt) && 𝒮.target_update(π⁻, π, i=𝒮.i + 1:𝒮.i + 𝒮.ΔN)
-            
-        end # end loop over A and P
+        elapsed(𝒮.i + 1:𝒮.i + ΔN, 𝒮.train_pro_every) && merge!(infos, train_step(𝒮.𝒮_pro, 𝒟_pro))
+        elapsed(𝒮.i + 1:𝒮.i + ΔN, 𝒮.train_ant_every) && merge!(infos, train_step(𝒮.𝒮_ant, 𝒟_ant))
         
         # Log the results
-        log(𝒮.log, 𝒮.i + 1:𝒮.i + 𝒮.ΔN, aggregate_info(infos))
+        log(𝒮.log, 𝒮.i + 1:𝒮.i + ΔN, aggregate_info(infos))
     end
     𝒮.i += 𝒮.ΔN
-    𝒮.π
+    𝒮.𝒮_pro.i = 𝒮.i
+    𝒮.𝒮_ant.i = 𝒮.i
+    
+    𝒮.𝒮_pro.π
 end
-

--- a/src/model_free/adversarial/adv_off_policy.jl
+++ b/src/model_free/adversarial/adv_off_policy.jl
@@ -64,8 +64,8 @@ function POMDPs.solve(𝒮::AdversarialOffPolicySolver, mdp)
         
         # Train the networks
         infos = []
-        elapsed(𝒮.i + 1:𝒮.i + ΔN, 𝒮.train_pro_every) && merge!(infos, train_step(𝒮.𝒮_pro, 𝒟_pro))
-        elapsed(𝒮.i + 1:𝒮.i + ΔN, 𝒮.train_ant_every) && merge!(infos, train_step(𝒮.𝒮_ant, 𝒟_ant))
+        elapsed(𝒮.i + 1:𝒮.i + ΔN, 𝒮.train_pro_every) && merge!(infos, train_step(𝒮.𝒮_pro, 𝒟_pro, γ))
+        elapsed(𝒮.i + 1:𝒮.i + ΔN, 𝒮.train_ant_every) && merge!(infos, train_step(𝒮.𝒮_ant, 𝒟_ant, γ))
         
         # Log the results
         log(𝒮.log, 𝒮.i + 1:𝒮.i + ΔN, aggregate_info(infos))

--- a/src/model_free/adversarial/isarl.jl
+++ b/src/model_free/adversarial/isarl.jl
@@ -1,0 +1,112 @@
+function IS_DQN_target(π, 𝒫, 𝒟, γ::Float32; kwargs...)
+        term = 𝒟[:done] .| 𝒟[:fail]
+        term .* Base.log.(𝒟[:fail] .+ 1f-16) .+ (1.f0 .- term) .* logsumexp(𝒫[:xlogprobs] .+ value(π, 𝒟[:sp]), dims=1)
+        # abs.(𝒟[:r]) .* (𝒟[:r] .< -10)  .+ (1.f0 .- 𝒟[:done]) .* γ .* sum(exp.(𝒫[:xlogprobs]) .* value(π, 𝒟[:sp]), dims=1)
+        # 𝒟[:done] .* 𝒟[:fail] .+ (1.f0 .- 𝒟[:done]) .* sum(exp.(𝒫[:xlogprobs]) .* value(π, 𝒟[:sp]), dims=1)
+end
+
+function IS_estimate_log_pfail(π, px, s, Nsamples=10)
+        xs_and_logpdfs = [exploration(π, s) for _ in 1:Nsamples]
+        xs = [e[1] for e in xs_and_logpdfs]
+        νlogpdfs = vcat([e[2] for e in xs_and_logpdfs]...)
+        logpfails = vcat([value(π, s, x) for x in xs]...)
+        logpxs = Float32.(vcat([logpdf.(px, x) for x in xs]...))
+
+        -Float32(Base.log(Nsamples)) .+ logsumexp(νlogpdfs .+ logpfails .- logpxs, dims=1)
+end
+
+function estimate_log_pfail(π, px, s, Nsamples=10)
+        xs = [reshape(rand(px, size(s,2)), :, size(s,2)) for _ in 1:Nsamples]
+        logpfails = vcat([value(π, s, x) for x in xs]...)
+
+        -Float32(Base.log(Nsamples)) .+ logsumexp(logpfails, dims=1)
+end
+
+function estimate_pfail(π, px, s, Nsamples=10)
+        xs = [reshape(rand(px, size(s,2)), :, size(s,2)) for _ in 1:Nsamples]
+        pfails = vcat([value(π, s, x) for x in xs]...)
+        
+        mean(pfails, dims=1)
+end
+
+function IS_Continuous_target(π, 𝒫, 𝒟, γ::Float32; kwargs...)
+        term = 𝒟[:done] .| 𝒟[:fail]
+        # term .* (𝒟[:fail] .== false) .* -100f0 .+ (1.f0 .- term) .* estimate_log_pfail(π, 𝒫[:px], 𝒟[:sp], 𝒫[:N_IS_Samples])
+        term .* 𝒟[:fail] .+ (1.f0 .- term) .* estimate_pfail(π, 𝒫[:px], 𝒟[:sp], 𝒫[:N_IS_Samples])
+end
+
+function IS_L_KL_log(π, 𝒫, 𝒟; kwargs...)
+        x, logνx = exploration(π, 𝒟[:s])
+        logpfail_s = Zygote.ignore() do 
+                estimate_log_pfail(π, 𝒫[:px], 𝒟[:s], 𝒫[:N_IS_Samples])
+        end
+        logpx = logpdf(𝒫[:px], x)
+        logpfail_sx = value(π, 𝒟[:s], x)
+        
+        
+        -mean(exp.( logpx .+ logpfail_sx .- logνx .- logpfail_s) .* logνx)
+end
+
+function IS_L_KL(π, 𝒫, 𝒟; kwargs...)
+        x, logνx = exploration(π, 𝒟[:s])
+        νx = exp.(logνx)
+        pfail_s = Zygote.ignore() do 
+                estimate_pfail(π, 𝒫[:px], 𝒟[:s], 𝒫[:N_IS_Samples])
+        end
+        px = exp.(logpdf(𝒫[:px], x))
+        pfail_sx = value(π, 𝒟[:s], x)
+        
+        
+        -mean(logνx .* px .* pfail_sx ./ (νx .* pfail_s))
+end
+
+
+function compute_IS_weight(𝒟, 𝒫; info=Dict())
+        𝒟[:weight] .= exp.(sum(𝒫[:xlogprobs] .* 𝒟[:x], dims=1) .- 𝒟[:xlogprob])
+        info[:mean_is_weight] = mean(𝒟[:weight])
+        info[:std_is_weight] = std(𝒟[:weight])
+        info[:min_is_weight] = minimum(𝒟[:weight])
+        info[:max_is_weight] = maximum(𝒟[:weight])
+end
+
+function compute_IS_weight_continuous(𝒟, 𝒫; info=Dict())
+        if 𝒫[:px] isa UnivariateDistribution
+                𝒟[:weight] .= clamp.(exp.(reshape(logpdf.(𝒫[:px], 𝒟[:x]), 1, :) .- 𝒟[:xlogprob]), 0f0, 5f0)
+        else
+                𝒟[:weight] .= clamp.(exp.(reshape(logpdf(𝒫[:px], 𝒟[:x]), 1, :) .- 𝒟[:xlogprob]), 0f0, 5f0)
+        end
+        info[:mean_is_weight] = mean(𝒟[:weight])
+        info[:std_is_weight] = std(𝒟[:weight])
+        info[:min_is_weight] = minimum(𝒟[:weight])
+        info[:max_is_weight] = maximum(𝒟[:weight])
+end
+
+ISARL_DQN(;kwargs...) = DQN(;c_loss=td_loss(name=:x_Qavg, a_key=:x), prefix="x_", target_fn=IS_DQN_target)
+ISARL_DDPG(;kwargs...) = DQN(;a_loss=IS_L_KL, c_loss=td_loss(name=:x_Qavg, a_key=:x), prefix="x_", target_fn=IS_Continuous_target, )
+
+function ISARL(;𝒮_pro,
+               𝒮_ant,
+               px,
+               log::NamedTuple=(;), 
+               train_pro_every::Int=1,
+               train_ant_every::Int=1,
+               buffer_size=1000, # Size of the buffer
+               required_columns=[:fail, :x, :xlogprob, :weight],
+               buffer::ExperienceBuffer=ExperienceBuffer(𝒮_pro.S, 𝒮_pro.agent.space, buffer_size, required_columns), # The replay buffer
+               buffer_init::Int = max(max(𝒮_pro.c_opt.batch_size, 𝒮_ant.c_opt.batch_size), 200) # Number of observations to initialize the buffer with
+               )
+               
+               # Set buffer parameters to be consistent between solvers (Since buffer is shared)
+       𝒮_pro.required_columns = required_columns
+       𝒮_pro.buffer = buffer
+       𝒮_pro.buffer_init = buffer_init
+       𝒮_ant.required_columns = required_columns
+       𝒮_ant.buffer = buffer    
+       𝒮_ant.buffer_init = buffer_init     
+        AdversarialOffPolicySolver(;𝒮_pro=𝒮_pro,
+                                    𝒮_ant=𝒮_ant,
+                                    px=px,
+                                    train_pro_every=train_pro_every,
+                                    train_ant_every=train_ant_every,
+                                    log=LoggerParams(;dir="log/isarl", log...),)
+end

--- a/src/model_free/adversarial/rarl.jl
+++ b/src/model_free/adversarial/rarl.jl
@@ -1,15 +1,37 @@
-RARL_DQN_target(π, 𝒫, 𝒟, γ::Float32; kwargs...) = -𝒟[:r] .+ γ .* (1.f0 .- 𝒟[:done]) .* maximum(value(π, 𝒟[:sp]), dims=1)
+function RARL_DQN_target(π, 𝒫, 𝒟, γ::Float32; kwargs...)
+         -𝒟[:r] .+ γ .* (1.f0 .- 𝒟[:done]) .* maximum(value(π, 𝒟[:sp]), dims=1)
+end
 
-RARL(;π::DiscreteNetwork, N::Int, ΔN=4, π_explore=ϵGreedyPolicy(LinearDecaySchedule(1., 0.1, floor(Int, N/2)), π.outputs), c_opt::NamedTuple=(;), log::NamedTuple=(;), kwargs...) = 
-        AdversarialOffPolicySolver(;
-                π=π, 
-                log=LoggerParams(;dir="log/dqn", log...),
-                N=N,
-                ΔN=ΔN,
-                c_opt = TrainingParams(;loss=td_loss, name="critic_", epochs=ΔN, c_opt...),
-                x_c_opt = TrainingParams(;loss=td_loss, name="x_critic_", epochs=ΔN, c_opt...),
-                target_fn=DQN_target,
-                x_target_fn=RARL_DQN_target,
-                π_explore=π_explore,
-                kwargs...)
+function RARL_TD3_target(π, 𝒫, 𝒟, γ::Float32; i) 
+    ap, _ = exploration(𝒫[:π_smooth], 𝒟[:sp], π_on=π, i=i)
+    y = -𝒟[:r] .+ γ .* (1.f0 .- 𝒟[:done]) .* min.(value(π, 𝒟[:sp], ap)...)
+end
 
+RARL_DQN(;kwargs...) = DQN(;c_loss=td_loss(name=:x_Qavg, a_key=:x), prefix="x_", target_fn=RARL_DQN_target)
+RARL_TD3(;kwargs...) = DQN(;c_loss=double_Q_loss(name=:x_Qavg, a_key=:x), prefix="x_", target_fn=RARL_TD3_target)
+
+function RARL(;𝒮_pro,
+               𝒮_ant,
+               px,
+               log::NamedTuple=(;), 
+               train_pro_every::Int=1,
+               train_ant_every::Int=1,
+               buffer_size=1000, # Size of the buffer
+               required_columns=Symbol[:x, :fail],
+               buffer::ExperienceBuffer=ExperienceBuffer(𝒮_pro.S, 𝒮_pro.agent.space, buffer_size, required_columns), # The replay buffer
+               buffer_init::Int=max(max(𝒮_pro.c_opt.batch_size, 𝒮_ant.c_opt.batch_size), 200) # Number of observations to initialize the buffer with
+               )
+        # Set buffer parameters to be consistent between solvers (Since buffer is shared)
+        𝒮_pro.required_columns = required_columns
+        𝒮_pro.buffer = buffer
+        𝒮_pro.buffer_init = buffer_init
+        𝒮_ant.required_columns = required_columns
+        𝒮_ant.buffer = buffer    
+        𝒮_ant.buffer_init = buffer_init    
+        AdversarialOffPolicySolver(;𝒮_pro=𝒮_pro,
+                                    𝒮_ant=𝒮_ant,
+                                    px=px,
+                                    train_pro_every=train_pro_every,
+                                    train_ant_every=train_ant_every,
+                                    log=LoggerParams(;dir="log/rarl", log...),)
+end

--- a/src/model_free/batch.jl
+++ b/src/model_free/batch.jl
@@ -1,26 +1,23 @@
 @with_kw mutable struct BatchSolver <: Solver
-    π # The policy to train
+    agent::PolicyParams
     S::AbstractSpace # State space
-    A::AbstractSpace = action_space(π) # Action space
     max_steps::Int = 100 # Maximum number of steps per episode
     𝒟_train # training data
     param_optimizers::Dict{Any, TrainingParams} = Dict() # Training parameters for the parameters
     a_opt::TrainingParams # Training parameters for the actor
     c_opt::Union{Nothing, TrainingParams} = nothing # Training parameters for the discriminator
     target_fn = nothing # the target function for value-based methods
-    π⁻ = deepcopy(π) # use a target policy for value-bsaed methods
     target_update = (π⁻, π; kwargs...) -> polyak_average!(π⁻, π, 0.005f0) # Function for updating the target network
     𝒫::NamedTuple = (;) # Parameters of the algorithm
     log::Union{Nothing, LoggerParams} = nothing # The logging parameters
     required_columns = Symbol[] # Extra columns to sample
     epoch = 0 # Number of epochs of training
-    
 end
 
 function POMDPs.solve(𝒮::BatchSolver, mdp)
     γ = Float32(discount(mdp))
     # Sampler for logging performance
-    s = Sampler(mdp, 𝒮.π, S=𝒮.S, A=𝒮.A, max_steps=𝒮.max_steps, required_columns=𝒮.required_columns)
+    s = Sampler(mdp, 𝒮.agent, S=𝒮.S, max_steps=𝒮.max_steps, required_columns=𝒮.required_columns)
     isnothing(𝒮.log.sampler) && (𝒮.log.sampler = s)
     
     # Log initial performance
@@ -43,23 +40,23 @@ function POMDPs.solve(𝒮::BatchSolver, mdp)
             
             # Train parameters
             for (θs, p_opt) in 𝒮.param_optimizers
-                train!(θs, (;kwargs...) -> p_opt.loss(𝒮.π, 𝒮.𝒫, mb; kwargs...), p_opt, info=info)
+                train!(θs, (;kwargs...) -> p_opt.loss(𝒮.agent.π, 𝒮.𝒫, mb; kwargs...), p_opt, info=info)
             end
             
             # Compute target
-            y = !isnothing(𝒮.target_fn) ? 𝒮.target_fn(𝒮.π⁻, 𝒮.𝒫, mb, γ) : nothing
+            y = !isnothing(𝒮.target_fn) ? 𝒮.target_fn(𝒮.agent.π⁻, 𝒮.𝒫, mb, γ) : nothing
             
             # Optionally train the critic
             if !isnothing(𝒮.c_opt)
-                train!(critic(𝒮.π), (;kwargs...)->𝒮.c_opt.loss(𝒮.π, 𝒮.𝒫, mb, y; kwargs...), 𝒮.c_opt, info=info)
+                train!(critic(𝒮.agent.π), (;kwargs...)->𝒮.c_opt.loss(𝒮.agent.π, 𝒮.𝒫, mb, y; kwargs...), 𝒮.c_opt, info=info)
                 
                 if !isnothing(y)
-                    𝒮.target_update(𝒮.π⁻, 𝒮.π)
+                    𝒮.target_update(𝒮.agent.π⁻, 𝒮.agent.π)
                 end
             end 
             
             # Train the actor
-            train!(actor(𝒮.π), (;kwargs...)->𝒮.a_opt.loss(𝒮.π, 𝒮.𝒫, mb; kwargs...), 𝒮.a_opt, info=info)
+            train!(actor(𝒮.agent.π), (;kwargs...)->𝒮.a_opt.loss(𝒮.agent.π, 𝒮.𝒫, mb; kwargs...), 𝒮.a_opt, info=info)
             
             grad_steps += 1
             log(𝒮.log, grad_steps, info)
@@ -72,22 +69,8 @@ function POMDPs.solve(𝒮::BatchSolver, mdp)
         𝒮.a_opt.early_stopping(infos) && break
     end
     
-    𝒮.π
+    𝒮.agent.π
 end
 
-# Early stopping function that terminates training on validation error increase
-function stop_on_validation_increase(π, 𝒫, 𝒟_val, loss; window=5)
-    k = "validation_error"
-    (infos) -> begin
-        ve = loss(π, 𝒫, 𝒟_val) # Compute the validation error
-        infos[end][k] = ve # store it
-        N = length(infos)
-        if length(infos) >= 2*window
-            curr_window = mean([infos[i][k] for i=N-window+1:N])
-            old_window = mean([infos[i][k] for i=N-2*window+1:N-window])
-            return curr_window >= old_window # check if the error has gone up
-        end
-        false
-    end
-end
+
 

--- a/src/model_free/batch/cql.jl
+++ b/src/model_free/batch/cql.jl
@@ -36,35 +36,38 @@ function conservative_loss(π, 𝒫, 𝒟; info=Dict())
     β * (5f0*loss - 𝒫[:CQL_α_thresh])
 end
 
-function CQL_critic_loss(π, 𝒫, 𝒟, y; info=Dict(), weighted=false)
-    loss = double_Q_loss(π, 𝒫, 𝒟, y, info=info)
-    c_loss = conservative_loss(π, 𝒫, 𝒟, info=info)
-    loss + c_loss
+function CQL_critic_loss(;kwargs...)
+    Q2loss = double_Q_loss(;kwargs...)
+    (π, 𝒫, 𝒟, y; info=Dict()) -> begin
+        loss = Q2loss(π, 𝒫, 𝒟, y, info=info)
+        c_loss = conservative_loss(π, 𝒫, 𝒟, info=info)
+        loss + c_loss
+    end
 end
 
 function CQL(;π::ActorCritic{T, DoubleNetwork{ContinuousNetwork, ContinuousNetwork}},
-    solver_type = BatchSAC,
-    CQL_α::Float32=1f0,
-    CQL_is_distribution = DistributionPolicy(product_distribution([Uniform(-1,1) for i=1:dim(action_space(π))[1]])),
-    CQL_α_thresh::Float32 = 10f0,
-    CQL_n_action_samples::Int = 10,
-    CQL_α_opt::NamedTuple=(;),
-    a_opt::NamedTuple=(;), 
-    c_opt::NamedTuple=(;), 
-    log::NamedTuple=(;),
-    kwargs...) where T
+              solver_type=BatchSAC,
+              CQL_α::Float32=1f0,
+              CQL_is_distribution=DistributionPolicy(product_distribution([Uniform(-1,1) for i=1:dim(action_space(π))[1]])),
+              CQL_α_thresh::Float32=10f0,
+              CQL_n_action_samples::Int=10,
+              CQL_α_opt::NamedTuple=(;),
+              a_opt::NamedTuple=(;), 
+              c_opt::NamedTuple=(;), 
+              log::NamedTuple=(;),
+              kwargs...) where T
     # Fill the parameters
     𝒫 = (CQL_log_α=[Base.log(CQL_α)],
           CQL_is_distribution=CQL_is_distribution,
           CQL_n_action_samples=CQL_n_action_samples,
           CQL_α_thresh=CQL_α_thresh)
     solver_type(;
-        π = π,
-        𝒫 = 𝒫,
-        log = (;dir = "log/cql", log...),
-        param_optimizers = Dict(Flux.params(𝒫[:CQL_log_α]) => TrainingParams(;loss=CQL_alpha_loss, name="CQL_alpha_", CQL_α_opt...)),
-        a_opt = a_opt,
-        c_opt = (loss=CQL_critic_loss, name="critic_", c_opt...),
+        π=π,
+        𝒫=𝒫,
+        log=(;dir = "log/cql", log...),
+        param_optimizers=Dict(Flux.params(𝒫[:CQL_log_α]) => TrainingParams(;loss=CQL_alpha_loss, name="CQL_alpha_", CQL_α_opt...)),
+        a_opt=a_opt,
+        c_opt=(loss=CQL_critic_loss(), name="critic_", c_opt...),
         kwargs...)
 end
 

--- a/src/model_free/batch/sac.jl
+++ b/src/model_free/batch/sac.jl
@@ -12,20 +12,20 @@ function BatchSAC(;π::ActorCritic{T, DoubleNetwork{ContinuousNetwork, Continuou
                    param_optimizers=Dict(), 
                    normalize_training_data = true, 
                    kwargs...) where T
-    normalize_training_data && (𝒟_train = normalize!(deepcopy(𝒟_train), S, A))
+    normalize_training_data && (𝒟_train = normalize!(deepcopy(𝒟_train), S, action_space(π)))
     𝒟_train = 𝒟_train |> device(π)
     
     𝒫 = (SAC_log_α = [Base.log(SAC_α)], SAC_H_target = SAC_H_target, 𝒫...)
-    BatchSolver(;
-        π=PolicyParams(π),
-        S=S,
-        𝒫=𝒫,
-        𝒟_train=𝒟_train,
-        log=LoggerParams(;dir = "log/batch_sac", log...),
-        param_optimizers=Dict(Flux.params(𝒫[:SAC_log_α]) => TrainingParams(;loss=SAC_temp_loss, name="temp_", SAC_α_opt...), param_optimizers...),
-        a_opt=TrainingParams(;loss=SAC_actor_loss, name="actor_", a_opt...),
-        c_opt=TrainingParams(;loss=double_Q_loss(), name="critic_", epochs=ΔN, c_opt...),
-        target_fn=SAC_target(π),
-        kwargs...)
+    BatchSolver(;agent=PolicyParams(π=π, π⁻=deepcopy(π)),
+                 S=S,
+                 𝒫=𝒫,
+                 𝒟_train=𝒟_train,
+                 log=LoggerParams(;dir = "log/batch_sac", log...),
+                 param_optimizers=Dict(Flux.params(𝒫[:SAC_log_α]) => TrainingParams(;loss=SAC_temp_loss, name="temp_", SAC_α_opt...), param_optimizers...),
+                 a_opt=TrainingParams(;loss=SAC_actor_loss, name="actor_", a_opt...),
+                 c_opt=TrainingParams(;loss=double_Q_loss(), name="critic_", epochs=ΔN, c_opt...),
+                 target_fn=SAC_target(π),
+                 kwargs...)
+        
 end
 

--- a/src/model_free/batch/sac.jl
+++ b/src/model_free/batch/sac.jl
@@ -1,19 +1,31 @@
-function BatchSAC(;π::ActorCritic{T, DoubleNetwork{ContinuousNetwork, ContinuousNetwork}}, S, A=action_space(π), ΔN=50, SAC_α::Float32=1f0, SAC_H_target::Float32 = Float32(-prod(dim(action_space(π)))), 𝒟_train, SAC_α_opt::NamedTuple=(;), a_opt::NamedTuple=(;), c_opt::NamedTuple=(;), log::NamedTuple=(;), 𝒫::NamedTuple=(;), param_optimizers=Dict(), normalize_training_data = true, kwargs...) where T
+function BatchSAC(;π::ActorCritic{T, DoubleNetwork{ContinuousNetwork, ContinuousNetwork}}, 
+                   S,
+                   ΔN=50, 
+                   SAC_α::Float32=1f0, 
+                   SAC_H_target::Float32 = Float32(-prod(dim(action_space(π)))), 
+                   𝒟_train, 
+                   SAC_α_opt::NamedTuple=(;), 
+                   a_opt::NamedTuple=(;), 
+                   c_opt::NamedTuple=(;), 
+                   log::NamedTuple=(;), 
+                   𝒫::NamedTuple=(;), 
+                   param_optimizers=Dict(), 
+                   normalize_training_data = true, 
+                   kwargs...) where T
     normalize_training_data && (𝒟_train = normalize!(deepcopy(𝒟_train), S, A))
     𝒟_train = 𝒟_train |> device(π)
     
     𝒫 = (SAC_log_α = [Base.log(SAC_α)], SAC_H_target = SAC_H_target, 𝒫...)
     BatchSolver(;
-        π = π,
+        π=PolicyParams(π),
         S=S,
-        A=A,
-        𝒫 = 𝒫,
+        𝒫=𝒫,
         𝒟_train=𝒟_train,
-        log = LoggerParams(;dir = "log/batch_sac", log...),
-        param_optimizers = Dict(Flux.params(𝒫[:SAC_log_α]) => TrainingParams(;loss=SAC_temp_loss, name="temp_", SAC_α_opt...), param_optimizers...),
-        a_opt = TrainingParams(;loss=SAC_actor_loss, name="actor_", a_opt...),
-        c_opt = TrainingParams(;loss=double_Q_loss, name="critic_", epochs=ΔN, c_opt...),
-        target_fn = SAC_target(π),
+        log=LoggerParams(;dir = "log/batch_sac", log...),
+        param_optimizers=Dict(Flux.params(𝒫[:SAC_log_α]) => TrainingParams(;loss=SAC_temp_loss, name="temp_", SAC_α_opt...), param_optimizers...),
+        a_opt=TrainingParams(;loss=SAC_actor_loss, name="actor_", a_opt...),
+        c_opt=TrainingParams(;loss=double_Q_loss(), name="critic_", epochs=ΔN, c_opt...),
+        target_fn=SAC_target(π),
         kwargs...)
 end
 

--- a/src/model_free/il/AdRIL.jl
+++ b/src/model_free/il/AdRIL.jl
@@ -1,6 +1,5 @@
 function AdRIL(;π, 
-                S, 
-                A=action_space(π), 
+                S,
                 ΔN=50,
                 solver=SAC, 
                 𝒟_demo, 
@@ -9,11 +8,11 @@ function AdRIL(;π,
                 buffer_size = 1000, 
                 buffer_init=0,
                 log::NamedTuple=(;),
-                buffer::ExperienceBuffer = ExperienceBuffer(S, A, buffer_size, [:i]), 
+                buffer::ExperienceBuffer = ExperienceBuffer(S, action_space(π), buffer_size, [:i]), 
                 kwargs...)
     
     !haskey(𝒟_demo, :r) && error("AdRIL requires a reward value for the demonstrations")
-    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, A))
+    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, action_space(π)))
     𝒟_demo = 𝒟_demo |> device(π)
     
     
@@ -29,7 +28,6 @@ function AdRIL(;π,
     
     solver(;π=π, 
             S=S, 
-            A=A,
             ΔN=ΔN, 
             post_experience_callback=AdRIL_callback, 
             extra_buffers=[𝒟_demo], 

--- a/src/model_free/il/AdVIL.jl
+++ b/src/model_free/il/AdVIL.jl
@@ -24,7 +24,7 @@ function AdVIL(;π,
     normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, action_space(π)))
     𝒟_demo = 𝒟_demo |> device(π)
     
-    BatchSolver(;π=PolicyParams(π),
+    BatchSolver(;agent=PolicyParams(π),
                  S=S,
                  𝒫=(λ_GP=λ_GP, λ_BC=λ_BC,),
                  𝒟_train = 𝒟_demo,

--- a/src/model_free/il/AdVIL.jl
+++ b/src/model_free/il/AdVIL.jl
@@ -9,12 +9,23 @@ function AdVIL_D_loss(π, 𝒫, 𝒟, y; info=Dict())
     mean(value(π, expert_sa)) - mean(value(π, π_sa)) + 𝒫[:λ_GP]*gradient_penalty(critic(π), expert_sa, π_sa, target=0.4f0)
 end
 
-function AdVIL(;π, S, A=action_space(π), 𝒟_demo, normalize_demo::Bool=true, λ_GP::Float32=10f0, λ_orth::Float32=1f-4, λ_BC::Float32=2f-1, a_opt::NamedTuple=(;), c_opt::NamedTuple=(;), log::NamedTuple=(;), kwargs...)
-    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, A))
+function AdVIL(;π, 
+                S,
+                𝒟_demo, 
+                normalize_demo::Bool=true, 
+                λ_GP::Float32=10f0, 
+                λ_orth::Float32=1f-4, 
+                λ_BC::Float32=2f-1, 
+                a_opt::NamedTuple=(;), 
+                c_opt::NamedTuple=(;), 
+                log::NamedTuple=(;), 
+                kwargs...)
+                
+    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, action_space(π)))
     𝒟_demo = 𝒟_demo |> device(π)
-    BatchSolver(;π=π,
+    
+    BatchSolver(;π=PolicyParams(π),
                  S=S,
-                 A=A,
                  𝒫=(λ_GP=λ_GP, λ_BC=λ_BC,),
                  𝒟_train = 𝒟_demo,
                  a_opt=TrainingParams(;name="actor_", loss=AdVIL_π_loss, regularizer=OrthogonalRegularizer(λ_orth), a_opt...),

--- a/src/model_free/il/asaf.jl
+++ b/src/model_free/il/asaf.jl
@@ -1,53 +1,5 @@
-@with_kw mutable struct ASAFSolver <: Solver
-    π # Policy
-    S::AbstractSpace # State space
-    A::AbstractSpace = action_space(π) # Action space
-    N::Int = 1000 # Number of environment interactions
-    ΔN::Int = 2000 # Number of interactions between updates
-    max_steps::Int = 100 # Maximum number of steps per episode
-    log::Union{Nothing, LoggerParams} = LoggerParams(;dir = "log/ASAF") # The logging parameters
-    i::Int = 0 # The current number of environment interactions
-    a_opt::TrainingParams # Training parameters for the actor
-    required_columns = Symbol[]
-    𝒟_demo
-end
-
-function ASAF(;π, S, A=action_space(π), 𝒟_demo, normalize_demo::Bool=true, ΔN=50, λ_orth=1f-4, a_opt::NamedTuple=(;), c_opt::NamedTuple=(;), log::NamedTuple=(;), kwargs...)
-    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, A))
-    𝒟_demo = 𝒟_demo |> device(π)
-    ASAFSolver(;π=π, 
-                 S=S, 
-                 A=A,
-                 𝒟_demo=𝒟_demo,
-                 ΔN=ΔN,
-                 log=LoggerParams(;dir="log/ASAF", period=100, log...),
-                 a_opt=TrainingParams(;name="actor_", loss=nothing, a_opt...), 
-                 kwargs...)
-end
-
-
-# function ASAF_actor_loss(πG)
-#     (π, 𝒟, 𝒟_demo; info=Dict()) -> begin
-#         πsa_G = exp.(logpdf(π, 𝒟[:s], 𝒟[:a]))
-#         πsa_E = exp.(logpdf(π, 𝒟_demo[:s], 𝒟_demo[:a]))
-#         πGsa_G = exp.(logpdf(πG, 𝒟[:s], 𝒟[:a]))
-#         πGsa_E = exp.(logpdf(πG, 𝒟_demo[:s], 𝒟_demo[:a]))
-#         e = mean(entropy(π, 𝒟[:s]))
-#         r = 𝒟_demo[:r]
-# 
-#         ignore() do
-#             info[:entropy] = e
-#         end 
-# 
-#         DE = πsa_E ./ (πsa_E .+ πGsa_E .+ 1f-3)
-#         DG = πsa_G ./ (πsa_G .+ πGsa_G .+ 1f-3)
-# 
-#         -Flux.mean(log.(1 .- r  .+ 2f0*(r .- 0.5f0) .* DE)) - Flux.mean(log.(1 .- DG))  - 0.1f0*e
-#     end
-# end
-
-function ASAF_actor_loss(πG)
-    (π, 𝒟, 𝒟_demo; info=Dict()) -> begin
+function ASAF_actor_loss(πG, 𝒟_demo)
+    (π, 𝒟; info=Dict()) -> begin
         πsa_G = logpdf(π, 𝒟[:s], 𝒟[:a])
         πsa_E = logpdf(π, 𝒟_demo[:s], 𝒟_demo[:a])
         πGsa_G = logpdf(πG, 𝒟[:s], 𝒟[:a])
@@ -68,28 +20,25 @@ function ASAF_actor_loss(πG)
     end
 end
 
-function POMDPs.solve(𝒮::ASAFSolver, mdp)
-    # Construct the training buffer, constants, and sampler
-    𝒟 = ExperienceBuffer(𝒮.S, 𝒮.A, 𝒮.ΔN, 𝒮.required_columns, device=device(𝒮.π))
-    s = Sampler(mdp, 𝒮.π, S=𝒮.S, A=𝒮.A, max_steps=𝒮.max_steps, π_explore=𝒮.π, required_columns=𝒮.required_columns)
-    isnothing(𝒮.log.sampler) && (𝒮.log.sampler = s)
 
-    # Log the pre-train performance
-    log(𝒮.log, 𝒮.i)
-
-    # Loop over the desired number of environment interactions
-    for 𝒮.i = range(𝒮.i, stop=𝒮.i + 𝒮.N - 𝒮.ΔN, step=𝒮.ΔN)
-        # Sample transitions into the batch buffer
-        push!(𝒟, steps!(s, Nsteps=𝒮.ΔN, reset=true, explore=true, i=𝒮.i))
-        
-        # Train the actor
-        𝒮.a_opt.loss = ASAF_actor_loss(deepcopy(𝒮.π))
-        info = batch_train!(actor(𝒮.π), 𝒮.a_opt, 𝒟, 𝒮.𝒟_demo)
-        
-        # Log the results
-        log(𝒮.log, 𝒮.i + 1:𝒮.i + 𝒮.ΔN, info)
-    end
-    𝒮.i += 𝒮.ΔN
-    𝒮.π
+function ASAF(;π, 
+               S, 
+               𝒟_demo, 
+               normalize_demo::Bool=true, 
+               ΔN=50, 
+               λ_orth=1f-4, 
+               a_opt::NamedTuple=(;), 
+               c_opt::NamedTuple=(;), 
+               log::NamedTuple=(;), 
+               kwargs...)
+               
+    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, A))
+    𝒟_demo = 𝒟_demo |> device(π)
+    OnPolicySolver(;π=PolicyParams(π), 
+                    S=S,
+                    ΔN=ΔN,
+                    loop_start_callback=(𝒮) -> 𝒮.a_opt.loss = ASAF_actor_loss(deepcopy(𝒮.π), 𝒟_demo),
+                    log=LoggerParams(;dir="log/ASAF", period=100, log...),
+                    a_opt=TrainingParams(;name="actor_", loss=nothing, a_opt...), 
+                    kwargs...)
 end
-

--- a/src/model_free/il/asaf.jl
+++ b/src/model_free/il/asaf.jl
@@ -1,5 +1,5 @@
 function ASAF_actor_loss(πG, 𝒟_demo)
-    (π, 𝒟; info=Dict()) -> begin
+    (π, 𝒫, 𝒟,; info=Dict()) -> begin
         πsa_G = logpdf(π, 𝒟[:s], 𝒟[:a])
         πsa_E = logpdf(π, 𝒟_demo[:s], 𝒟_demo[:a])
         πGsa_G = logpdf(πG, 𝒟[:s], 𝒟[:a])
@@ -32,13 +32,14 @@ function ASAF(;π,
                log::NamedTuple=(;), 
                kwargs...)
                
-    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, A))
+    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, action_space(π)))
     𝒟_demo = 𝒟_demo |> device(π)
-    OnPolicySolver(;π=PolicyParams(π), 
+    OnPolicySolver(;agent=PolicyParams(π), 
                     S=S,
                     ΔN=ΔN,
-                    loop_start_callback=(𝒮) -> 𝒮.a_opt.loss = ASAF_actor_loss(deepcopy(𝒮.π), 𝒟_demo),
+                    loop_start_callback=(𝒮) -> 𝒮.a_opt.loss = ASAF_actor_loss(deepcopy(𝒮.agent.π), 𝒟_demo),
                     log=LoggerParams(;dir="log/ASAF", period=100, log...),
                     a_opt=TrainingParams(;name="actor_", loss=nothing, a_opt...), 
                     kwargs...)
 end
+

--- a/src/model_free/il/bc.jl
+++ b/src/model_free/il/bc.jl
@@ -16,11 +16,22 @@ function logpdf_bc_loss(π, 𝒫, 𝒟; info=Dict())
     𝒫[:λe]*eloss + lloss
 end
 
-function BC(;π, S, A=action_space(π), 𝒟_demo, normalize_demo::Bool=true, loss=nothing, validation_fraction=0.3, window=100, λe::Float32=1f-3, opt::NamedTuple=(;), log::NamedTuple=(;), kwargs...)
+function BC(;π, 
+             S, 
+             𝒟_demo, 
+             normalize_demo::Bool=true, 
+             loss=nothing, 
+             validation_fraction=0.3, 
+             window=100, 
+             λe::Float32=1f-3, 
+             opt::NamedTuple=(;), 
+             log::NamedTuple=(;), 
+             kwargs...)
+             
     if isnothing(loss)
         loss = π isa ContinuousNetwork ? mse_action_loss : logpdf_bc_loss
     end
-    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, A))
+    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, action_space(π)))
     𝒟_demo = 𝒟_demo |> device(π)
     
     # Split between train and validation sets
@@ -29,13 +40,12 @@ function BC(;π, S, A=action_space(π), 𝒟_demo, normalize_demo::Bool=true, lo
     #TODO: We should include a validation loss, then early stopping should just analyze the history of the validation loss. 
     
     𝒫 = (λe=λe,)
-    BatchSolver(;π=π, 
-              S=S,
-              A=A,
-              𝒫=𝒫,
-              𝒟_train=𝒟_train, 
-              a_opt=TrainingParams(;early_stopping=stop_on_validation_increase(π, 𝒫, 𝒟_validate, loss, window=window), loss=loss, opt...), 
-              log=LoggerParams(;dir="log/bc", period=1, log...),
-              kwargs...)
+    BatchSolver(;π=PolicyParams(π), 
+                 S=S,
+                 𝒫=𝒫,
+                 𝒟_train=𝒟_train, 
+                 a_opt=TrainingParams(;early_stopping=stop_on_validation_increase(π, 𝒫, 𝒟_validate, loss, window=window), loss=loss, opt...), 
+                 log=LoggerParams(;dir="log/bc", period=1, log...),
+                 kwargs...)
 end
 

--- a/src/model_free/il/bc.jl
+++ b/src/model_free/il/bc.jl
@@ -40,7 +40,7 @@ function BC(;π,
     #TODO: We should include a validation loss, then early stopping should just analyze the history of the validation loss. 
     
     𝒫 = (λe=λe,)
-    BatchSolver(;π=PolicyParams(π), 
+    BatchSolver(;agent=PolicyParams(π), 
                  S=S,
                  𝒫=𝒫,
                  𝒟_train=𝒟_train, 

--- a/src/model_free/il/off_policy_gail.jl
+++ b/src/model_free/il/off_policy_gail.jl
@@ -1,4 +1,14 @@
-function OffPolicyGAIL(;π, S, A=action_space(π), 𝒟_demo, 𝒟_ndas::Array{ExperienceBuffer} = ExperienceBuffer[], normalize_demo::Bool=true, D::ContinuousNetwork, solver=SAC, d_opt::NamedTuple=(epochs=5,), log::NamedTuple=(;), kwargs...)
+function OffPolicyGAIL(;π, 
+                        S, 
+                        𝒟_demo, 
+                        𝒟_ndas::Array{ExperienceBuffer} = ExperienceBuffer[], 
+                        normalize_demo::Bool=true, 
+                        D::ContinuousNetwork, 
+                        solver=SAC, 
+                        d_opt::NamedTuple=(epochs=5,), 
+                        log::NamedTuple=(;), 
+                        kwargs...)
+                        
     # Define the training parameters for the desciminator
     d_opt = TrainingParams(;name="discriminator_", loss=()->nothing, d_opt...)
     
@@ -9,6 +19,7 @@ function OffPolicyGAIL(;π, S, A=action_space(π), 𝒟_demo, 𝒟_ndas::Array{E
     
     # Normalize and/or change device of expert and NDA data
     dev = device(π)
+    A = action_space(π)
     normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, A))
     𝒟_demo = 𝒟_demo |> dev
     for i in 1:N_nda
@@ -17,10 +28,11 @@ function OffPolicyGAIL(;π, S, A=action_space(π), 𝒟_demo, 𝒟_ndas::Array{E
     end
 
     # Build the solver
-    𝒮 = solver(;π=π, S=S, A=A, 
-            post_experience_callback=(𝒟; kwargs...) -> 𝒟[:r] .= 0, # This zeros out the reward that is collected so we don't accidentally use it. 
-            log=(dir="log/offpolicygail", period=500, log...),
-            kwargs...)
+    𝒮 = solver(;π=π, 
+                S=S,
+                post_experience_callback=(𝒟; kwargs...) -> 𝒟[:r] .= 0, # This zeros out the reward that is collected so we don't accidentally use it. 
+                log=(dir="log/offpolicygail", period=500, log...),
+                kwargs...)
             
     # Setup the training of the discriminator
     B = d_opt.batch_size

--- a/src/model_free/il/on_policy_gail.jl
+++ b/src/model_free/il/on_policy_gail.jl
@@ -4,20 +4,30 @@ function GAIL_D_loss(gan_loss)
     end
 end
 
-function OnPolicyGAIL(;π, S, A=action_space(π), 𝒟_demo, normalize_demo::Bool=true, D::ContinuousNetwork, solver=PPO, gan_loss::GANLoss=GAN_BCELoss(), d_opt::NamedTuple=(;), log::NamedTuple=(;),  kwargs...)
+function OnPolicyGAIL(;π, 
+                       S, 
+                       𝒟_demo, 
+                       normalize_demo::Bool=true, 
+                       D::ContinuousNetwork, 
+                       solver=PPO, 
+                       gan_loss::GANLoss=GAN_BCELoss(), 
+                       d_opt::NamedTuple=(;), 
+                       log::NamedTuple=(;),  
+                       kwargs...)
+                       
     d_opt = TrainingParams(;loss = GAIL_D_loss(gan_loss), name="discriminator_", d_opt...)
-    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, A))
+    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, action_space(π)))
     𝒟_demo = 𝒟_demo |> device(π)
     
     function GAIL_callback(𝒟; info=Dict())
         batch_train!(D, d_opt, (;), 𝒟_demo, 𝒟, info=info)
         
         discriminator_signal = haskey(𝒟, :advantage) ? :advantage : :return
-        D_out = value(D, 𝒟[:a], 𝒟[:s])
+        D_out = value(D, 𝒟[:a], 𝒟[:s]) # This is swapped because a->x and s->y and the convention for GANs is D(x,y)
         r = Base.log.(sigmoid.(D_out) .+ 1f-5) .- Base.log.(1f0 .- sigmoid.(D_out) .+ 1f-5)
-        𝒟[discriminator_signal] .= r # This is swapped because a->x and s->y and the convention for GANs is D(x,y)
+        𝒟[discriminator_signal] .= r 
     end
-    𝒮 = solver(;π=π, S=S, A=A, post_batch_callback=GAIL_callback, log=(dir="log/onpolicygail", period=500, log...), kwargs...)
+    𝒮 = solver(;π=π, S=S, post_batch_callback=GAIL_callback, log=(dir="log/onpolicygail", period=500, log...), kwargs...)
     𝒮.c_opt = nothing # disable the critic 
     𝒮
 end

--- a/src/model_free/il/sqil.jl
+++ b/src/model_free/il/sqil.jl
@@ -2,13 +2,19 @@ function SQIL_callback(𝒟)
     𝒟[:r] .= 0
 end
 
-function SQIL(;π, S, A=action_space(π), 𝒟_demo, normalize_demo::Bool=true, solver=SAC, log::NamedTuple=(;), kwargs...)
+function SQIL(;π, 
+               S, 
+               𝒟_demo, 
+               normalize_demo::Bool=true, 
+               solver=SAC, 
+               log::NamedTuple=(;), 
+               kwargs...)
+               
     !haskey(𝒟_demo, :r) && error("SQIL requires a reward value for the demonstrations")
-    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, A))
+    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, action_space(π)))
     𝒟_demo = 𝒟_demo |> device(π)
     solver(;π=π, 
             S=S, 
-            A=A, 
             post_experience_callback=SQIL_callback, 
             extra_buffers=[𝒟_demo],
             buffer_fractions=[1/2, 1/2],

--- a/src/model_free/off_policy.jl
+++ b/src/model_free/off_policy.jl
@@ -25,7 +25,7 @@
     buffer_fractions = [1.0] # Fraction of the minibatch devoted to each buffer
 end
 
-function train_step(𝒮::OffPolicySolver, 𝒟)
+function train_step(𝒮::OffPolicySolver, 𝒟, γ)
     infos = []
     # Loop over the desired number of training steps
     for epoch in 1:𝒮.c_opt.epochs
@@ -97,7 +97,7 @@ function POMDPs.solve(𝒮::OffPolicySolver, mdp)
         𝒮.post_experience_callback(𝒮.buffer) 
         
         # Train the networks
-        infos = train_step(𝒮, 𝒟)
+        infos = train_step(𝒮, 𝒟, γ)
         
         # Log the results
         log(𝒮.log, 𝒮.i + 1:𝒮.i + 𝒮.ΔN, aggregate_info(infos))

--- a/src/model_free/off_policy.jl
+++ b/src/model_free/off_policy.jl
@@ -1,7 +1,6 @@
 @with_kw mutable struct OffPolicySolver <: Solver
-    π # Policy
+    agent::PolicyParams # Policy
     S::AbstractSpace # State space
-    A::AbstractSpace = action_space(π) # Action space
     N::Int = 1000 # Number of environment interactions
     ΔN::Int = 4 # Number of interactions between updates
     max_steps::Int = 100 # Maximum number of steps per episode
@@ -12,26 +11,72 @@
     c_opt::TrainingParams # Training parameters for the critic
     post_experience_callback = (buffer) -> nothing
     post_batch_callback = (𝒟; kwargs...) -> nothing
+    loop_start_callback = (𝒮) -> nothing # Callback that happens at the beginning of each experience gathering iteration
     𝒫::NamedTuple = (;) # Parameters of the algorithm
     
     # Off-policy-specific parameters
-    π⁻ = deepcopy(π)
-    π_explore::Policy # exploration noise
     target_update = (π⁻, π; kwargs...) -> polyak_average!(π⁻, π, 0.005f0) # Function for updating the target network
     target_fn # Target for critic regression with input signature (π⁻, 𝒟, γ; i)
     buffer_size = 1000 # Size of the buffer
     required_columns = Symbol[]
-    buffer::ExperienceBuffer = ExperienceBuffer(S, A, buffer_size, required_columns) # The replay buffer
+    buffer::ExperienceBuffer = ExperienceBuffer(S, agent.space, buffer_size, required_columns) # The replay buffer
     buffer_init::Int = max(c_opt.batch_size, 200) # Number of observations to initialize the buffer with
     extra_buffers = [] # extra buffers (i.e. for experience replay in continual learning)
     buffer_fractions = [1.0] # Fraction of the minibatch devoted to each buffer
 end
 
+function train_step(𝒮::OffPolicySolver, 𝒟)
+    infos = []
+    # Loop over the desired number of training steps
+    for epoch in 1:𝒮.c_opt.epochs
+        # Sample a random minibatch of 𝑁 transitions (sᵢ, aᵢ, rᵢ, sᵢ₊₁) from 𝒟
+        rand!(𝒟, 𝒮.buffer, 𝒮.extra_buffers..., fracs=𝒮.buffer_fractions, i=𝒮.i)
+        
+        # Dictionary to store info from the various optimization processes
+        info = Dict()
+        
+        # Callack for potentially updating the buffer
+        𝒮.post_batch_callback(𝒟, info=info)
+        
+        # Compute target
+        y = 𝒮.target_fn(𝒮.agent.π⁻, 𝒮.𝒫, 𝒟, γ, i=𝒮.i)
+        
+        # Update priorities (for prioritized replay)
+        isprioritized(𝒮.buffer) && update_priorities!(𝒮.buffer, 𝒟.indices, cpu(td_error(𝒮.agent.π, 𝒟, y)))
+        
+        # Train parameters
+        for (θs, p_opt) in 𝒮.param_optimizers
+            train!(θs, (;kwargs...) -> p_opt.loss(𝒮.agent.π, 𝒮.𝒫, 𝒟; kwargs...), p_opt, info=info)
+        end
+        
+        # Train the critic
+        if ((epoch-1) % 𝒮.c_opt.update_every) == 0
+            train!(critic(𝒮.agent.π), (;kwargs...) -> 𝒮.c_opt.loss(𝒮.agent.π, 𝒮.𝒫, 𝒟, y; kwargs...), 𝒮.c_opt, info=info)
+        end
+        
+        # Train the actor 
+        if !isnothing(𝒮.a_opt) && ((epoch-1) % 𝒮.a_opt.update_every) == 0
+            train!(actor(𝒮.agent.π), (;kwargs...) -> 𝒮.a_opt.loss(𝒮.agent.π, 𝒮.𝒫, 𝒟; kwargs...), 𝒮.a_opt, info=info)
+        
+            # Update the target network
+            𝒮.target_update(𝒮.agent.π⁻, 𝒮.agent.π)
+        end
+        
+        # Store the training information
+        push!(infos, info)
+        
+    end
+    # If not using a separate actor, update target networks after critic training
+    isnothing(𝒮.a_opt) && 𝒮.target_update(𝒮.agent.π⁻, 𝒮.agent.π, i=𝒮.i + 1:𝒮.i + 𝒮.ΔN)
+    
+    infos
+end
+
 function POMDPs.solve(𝒮::OffPolicySolver, mdp)
     # Construct the training buffer, constants, and sampler
-    𝒟 = buffer_like(𝒮.buffer, capacity=𝒮.c_opt.batch_size, device=device(𝒮.π))
+    𝒟 = buffer_like(𝒮.buffer, capacity=𝒮.c_opt.batch_size, device=device(𝒮.agent.π))
     γ = Float32(discount(mdp))
-    s = Sampler(mdp, 𝒮.π, S=𝒮.S, A=𝒮.A, max_steps=𝒮.max_steps, π_explore=𝒮.π_explore, required_columns=extra_columns(𝒮.buffer))
+    s = Sampler(mdp, 𝒮.agent, S=𝒮.S, max_steps=𝒮.max_steps, required_columns=extra_columns(𝒮.buffer))
     isnothing(𝒮.log.sampler) && (𝒮.log.sampler = s)
 
     # Log the pre-train performance
@@ -42,79 +87,24 @@ function POMDPs.solve(𝒮::OffPolicySolver, mdp)
     
     # Loop over the desired number of environment interactions
     for 𝒮.i in range(𝒮.i, stop=𝒮.i + 𝒮.N - 𝒮.ΔN, step=𝒮.ΔN)
+        # Call the loop start callback function
+        𝒮.loop_start_callback(𝒮)
+        
         # Sample transitions into the replay buffer
         push!(𝒮.buffer, steps!(s, Nsteps=𝒮.ΔN, explore=true, i=𝒮.i))
         
         # callback for potentially updating the buffer
         𝒮.post_experience_callback(𝒮.buffer) 
         
-        infos = []
-        # Loop over the desired number of training steps
-        for epoch in 1:𝒮.c_opt.epochs
-            # Sample a random minibatch of 𝑁 transitions (sᵢ, aᵢ, rᵢ, sᵢ₊₁) from 𝒟
-            rand!(𝒟, 𝒮.buffer, 𝒮.extra_buffers..., fracs=𝒮.buffer_fractions, i=𝒮.i)
-            
-            # Dictionary to store info from the various optimization processes
-            info = Dict()
-            
-            # Callack for potentially updating the buffer
-            𝒮.post_batch_callback(𝒟, info=info)
-            
-            # Compute target
-            y = 𝒮.target_fn(𝒮.π⁻, 𝒮.𝒫, 𝒟, γ, i=𝒮.i)
-            
-            # Update priorities (for prioritized replay)
-            (ispri = isprioritized(𝒮.buffer)) && update_priorities!(𝒮.buffer, 𝒟.indices, cpu(td_error(𝒮.π, 𝒟, y)))
-            
-            # Train parameters
-            for (θs, p_opt) in 𝒮.param_optimizers
-                train!(θs, (;kwargs...) -> p_opt.loss(𝒮.π, 𝒮.𝒫, 𝒟; kwargs...), p_opt, info=info)
-            end
-            
-            # Train the critic
-            if ((epoch-1) % 𝒮.c_opt.update_every) == 0
-                train!(critic(𝒮.π), (;kwargs...) -> 𝒮.c_opt.loss(𝒮.π, 𝒮.𝒫, 𝒟, y; weighted=ispri, kwargs...), 𝒮.c_opt, info=info)
-            end
-            
-            # Train the actor 
-            if !isnothing(𝒮.a_opt) && ((epoch-1) % 𝒮.a_opt.update_every) == 0
-                train!(actor(𝒮.π), (;kwargs...) -> 𝒮.a_opt.loss(𝒮.π, 𝒮.𝒫, 𝒟; kwargs...), 𝒮.a_opt, info=info)
-            
-                # Update the target network
-                𝒮.target_update(𝒮.π⁻, 𝒮.π)
-            end
-            
-            # Store the training information
-            push!(infos, info)
-            
-        end
-        # If not using a separate actor, update target networks after critic training
-        isnothing(𝒮.a_opt) && 𝒮.target_update(𝒮.π⁻, 𝒮.π, i=𝒮.i + 1:𝒮.i + 𝒮.ΔN)
+        # Train the networks
+        infos = train_step(𝒮, 𝒟)
         
         # Log the results
         log(𝒮.log, 𝒮.i + 1:𝒮.i + 𝒮.ΔN, aggregate_info(infos))
     end
     𝒮.i += 𝒮.ΔN
-    𝒮.π
+    𝒮.agent.π
 end
 
-function td_loss(π, 𝒫, 𝒟, y; loss=Flux.mse, weighted=false, name=:Qavg, info=Dict())
-    Q = value(π, 𝒟[:s], 𝒟[:a]) 
-    
-    # Store useful information
-    ignore() do
-        info[name] = mean(Q)
-    end
-    
-    loss(Q, y, agg = weighted ? weighted_mean(𝒟[:weight]) : mean)
-end
-
-function double_Q_loss(π, 𝒫, 𝒟, y; info=Dict(), weighted=false)
-    q1loss = td_loss(π.C.N1, 𝒫, 𝒟, y, info=info, name=:Q1avg, weighted=weighted)
-    q2loss = td_loss(π.C.N2, 𝒫, 𝒟, y, info=info, name=:Q2avg, weighted=weighted)
-    0.5f0*q1loss + 0.5f0*q2loss
-end
-
-td_error(π, 𝒟, y) = abs.(value(π, 𝒟[:s], 𝒟[:a])  .- y)
 
 

--- a/src/model_free/on_policy.jl
+++ b/src/model_free/on_policy.jl
@@ -1,7 +1,6 @@
 @with_kw mutable struct OnPolicySolver <: Solver
-    π # Policy
+    agent::PolicyParams # Policy
     S::AbstractSpace # State space
-    A::AbstractSpace = action_space(π) # Action space
     N::Int = 1000 # Number of environment interactions
     ΔN::Int = 200 # Number of interactions between updates
     max_steps::Int = 100 # Maximum number of steps per episode
@@ -15,13 +14,14 @@
     λ_gae::Float32 = 0.95 # Generalized advantage estimation parameter
     required_columns = isnothing(c_opt) ? [:return, :logprob] : [:return, :advantage, :logprob] # Extra data columns to store
     post_batch_callback = (𝒟; kwargs...) -> nothing # Callback that that happens after sampling a batch
+    loop_start_callback = (𝒮) -> nothing # Callback that happens at the beginning of each experience gathering iteration
 end
 
 function POMDPs.solve(𝒮::OnPolicySolver, mdp)
     # Construct the training buffer, constants, and sampler
-    𝒟 = ExperienceBuffer(𝒮.S, 𝒮.A, 𝒮.ΔN, 𝒮.required_columns, device=device(𝒮.π))
+    𝒟 = ExperienceBuffer(𝒮.S, 𝒮.A, 𝒮.ΔN, 𝒮.required_columns, device=device(𝒮.agent.π))
     γ, λ = Float32(discount(mdp)), 𝒮.λ_gae
-    s = Sampler(mdp, 𝒮.π, S=𝒮.S, A=𝒮.A, required_columns=𝒮.required_columns, λ=λ, max_steps=𝒮.max_steps, π_explore=𝒮.π)
+    s = Sampler(mdp, 𝒮.agent, S=𝒮.S, required_columns=𝒮.required_columns, λ=λ, max_steps=𝒮.max_steps)
     isnothing(𝒮.log.sampler) && (𝒮.log.sampler = s)
 
     # Log the pre-train performance
@@ -29,6 +29,9 @@ function POMDPs.solve(𝒮::OnPolicySolver, mdp)
 
     # Loop over the desired number of environment interactions
     for 𝒮.i = range(𝒮.i, stop=𝒮.i + 𝒮.N - 𝒮.ΔN, step=𝒮.ΔN)
+        # Call the loop start callback function
+        𝒮.loop_start_callback(𝒮)
+        
         # Sample transitions into the batch buffer
         push!(𝒟, steps!(s, Nsteps=𝒮.ΔN, reset=true, explore=true, i=𝒮.i))
         
@@ -39,17 +42,17 @@ function POMDPs.solve(𝒮::OnPolicySolver, mdp)
         𝒮.post_batch_callback(𝒟, info=info)
         
         # Train the actor
-        batch_train!(actor(𝒮.π), 𝒮.a_opt, 𝒮.𝒫, 𝒟, info=info)
+        batch_train!(actor(𝒮.agent.π), 𝒮.a_opt, 𝒮.𝒫, 𝒟, info=info)
         
         # Train the critic (if applicable)
         if !isnothing(𝒮.c_opt)
-            batch_train!(critic(𝒮.π), 𝒮.c_opt, 𝒮.𝒫, 𝒟, info=info)
+            batch_train!(critic(𝒮.agent.π), 𝒮.c_opt, 𝒮.𝒫, 𝒟, info=info)
         end
         
         # Log the results
         log(𝒮.log, 𝒮.i + 1:𝒮.i + 𝒮.ΔN, info)
     end
     𝒮.i += 𝒮.ΔN
-    𝒮.π
+    𝒮.agent.π
 end
 

--- a/src/model_free/on_policy.jl
+++ b/src/model_free/on_policy.jl
@@ -19,7 +19,7 @@ end
 
 function POMDPs.solve(𝒮::OnPolicySolver, mdp)
     # Construct the training buffer, constants, and sampler
-    𝒟 = ExperienceBuffer(𝒮.S, 𝒮.A, 𝒮.ΔN, 𝒮.required_columns, device=device(𝒮.agent.π))
+    𝒟 = ExperienceBuffer(𝒮.S, 𝒮.agent.space, 𝒮.ΔN, 𝒮.required_columns, device=device(𝒮.agent.π))
     γ, λ = Float32(discount(mdp)), 𝒮.λ_gae
     s = Sampler(mdp, 𝒮.agent, S=𝒮.S, required_columns=𝒮.required_columns, λ=λ, max_steps=𝒮.max_steps)
     isnothing(𝒮.log.sampler) && (𝒮.log.sampler = s)

--- a/src/model_free/rl/a2c.jl
+++ b/src/model_free/rl/a2c.jl
@@ -12,15 +12,22 @@ function a2c_loss(π, 𝒫, 𝒟; info = Dict())
     𝒫[:λp]*p_loss + 𝒫[:λe]*e_loss
 end
 
-A2C(;π::ActorCritic, a_opt::NamedTuple=(;), c_opt::NamedTuple=(;), log::NamedTuple=(;), λp::Float32 = 1f0, λe::Float32 = 0.1f0, kwargs...) = 
-    OnPolicySolver(;
-        π = π,
-        𝒫=(λp=λp, λe=λe),
-        log=LoggerParams(;dir = "log/a2c", log...),
-        a_opt=TrainingParams(;loss=a2c_loss, early_stopping = (infos) -> (infos[end][:kl] > 0.015), name = "actor_", a_opt...),
-        c_opt=TrainingParams(;loss=(π, 𝒫, D; kwargs...) -> Flux.mse(value(π, D[:s]), D[:return]), name = "critic_", c_opt...),
-        post_batch_callback=(𝒟; kwargs...) -> (𝒟[:advantage] .= whiten(𝒟[:advantage])),
-        kwargs...)
+function A2C(;π::ActorCritic, 
+              a_opt::NamedTuple=(;), 
+              c_opt::NamedTuple=(;), 
+              log::NamedTuple=(;), 
+              λp::Float32=1f0, 
+              λe::Float32=0.1f0, kwargs...)
+              
+    OnPolicySolver(;π=PolicyParams(π),
+                    𝒫=(λp=λp, λe=λe),
+                    log=LoggerParams(;dir = "log/a2c", log...),
+                    a_opt=TrainingParams(;loss=a2c_loss, early_stopping = (infos) -> (infos[end][:kl] > 0.015), name = "actor_", a_opt...),
+                    c_opt=TrainingParams(;loss=(π, 𝒫, D; kwargs...) -> Flux.mse(value(π, D[:s]), D[:return]), name = "critic_", c_opt...),
+                    post_batch_callback=(𝒟; kwargs...) -> (𝒟[:advantage] .= whiten(𝒟[:advantage])),
+                    kwargs...)
+end
+        
     
 
 

--- a/src/model_free/rl/a2c.jl
+++ b/src/model_free/rl/a2c.jl
@@ -19,7 +19,7 @@ function A2C(;π::ActorCritic,
               λp::Float32=1f0, 
               λe::Float32=0.1f0, kwargs...)
               
-    OnPolicySolver(;π=PolicyParams(π),
+    OnPolicySolver(;agent=PolicyParams(π),
                     𝒫=(λp=λp, λe=λe),
                     log=LoggerParams(;dir = "log/a2c", log...),
                     a_opt=TrainingParams(;loss=a2c_loss, early_stopping = (infos) -> (infos[end][:kl] > 0.015), name = "actor_", a_opt...),

--- a/src/model_free/rl/ddpg.jl
+++ b/src/model_free/rl/ddpg.jl
@@ -1,5 +1,7 @@
 # Set yᵢ = rᵢ + γQ′(sᵢ₊₁, μ′(sᵢ₊₁ | θᵘ′) | θᶜ′)
-DDPG_target(π, 𝒫, 𝒟, γ::Float32; kwargs...) = 𝒟[:r] .+ γ .* (1.f0 .- 𝒟[:done]) .* value(π, 𝒟[:sp], action(π, 𝒟[:sp]))
+function DDPG_target(π, 𝒫, 𝒟, γ::Float32; kwargs...)
+    𝒟[:r] .+ γ .* (1.f0 .- 𝒟[:done]) .* value(π, 𝒟[:sp], action(π, 𝒟[:sp]))
+end
 
 function smoothed_DDPG_target(π, 𝒫, 𝒟, γ::Float32; i)
     ap, _ = exploration(𝒫[:π_smooth], 𝒟[:sp], π_on=π, i=i)
@@ -10,15 +12,26 @@ end
 DDPG_actor_loss(π, 𝒫, 𝒟; info=Dict()) = -mean(value(π, 𝒟[:s], action(π, 𝒟[:s])))
 
 # T. P. Lillicrap, et al., "Continuous control with deep reinforcement learning", ICLR 2016.
-DDPG(;π::ActorCritic, ΔN=50, π_explore=GaussianNoiseExplorationPolicy(0.1f0),  a_opt::NamedTuple=(;), c_opt::NamedTuple=(;), log::NamedTuple=(;), π_smooth=GaussianNoiseExplorationPolicy(0.1f0, ϵ_min=-0.5f0, ϵ_max=0.5f0), kwargs...) = 
-    OffPolicySolver(;
-        π=π, 
-        ΔN=ΔN,
-        𝒫=(π_smooth=π_smooth,),
-        log=LoggerParams(;dir = "log/ddpg", log...),
-        a_opt=TrainingParams(;loss=DDPG_actor_loss, name="actor_", a_opt...),
-        c_opt=TrainingParams(;loss=td_loss, name="critic_", epochs=ΔN, c_opt...),
-        π_explore=π_explore,
-        target_fn=DDPG_target,
-        kwargs...)
+function DDPG(;π::ActorCritic, 
+               ΔN=50, 
+               π_explore=GaussianNoiseExplorationPolicy(0.1f0),  
+               a_opt::NamedTuple=(;), 
+               c_opt::NamedTuple=(;),
+               a_loss=DDPG_actor_loss,
+               c_loss=td_loss(),
+               target_fn=DDPG_target,
+               prefix="",
+               log::NamedTuple=(;), 
+               π_smooth=GaussianNoiseExplorationPolicy(0.1f0, ϵ_min=-0.5f0, ϵ_max=0.5f0), kwargs...)
+               
+    OffPolicySolver(;π=PolicyParams(π=π, π_explore=π_explore, π⁻=deepcopy(π)), 
+                     ΔN=ΔN,
+                     𝒫=(π_smooth=π_smooth,),
+                     log=LoggerParams(;dir = "log/ddpg", log...),
+                     a_opt=TrainingParams(;loss=a_loss, name=string(prefix, "actor_"), a_opt...),
+                     c_opt=TrainingParams(;loss=c_loss, name=string(prefix, "critic_"), epochs=ΔN, c_opt...),
+                     target_fn=target_fn,
+                     kwargs...)
+end 
+        
 

--- a/src/model_free/rl/ddpg.jl
+++ b/src/model_free/rl/ddpg.jl
@@ -24,7 +24,7 @@ function DDPG(;π::ActorCritic,
                log::NamedTuple=(;), 
                π_smooth=GaussianNoiseExplorationPolicy(0.1f0, ϵ_min=-0.5f0, ϵ_max=0.5f0), kwargs...)
                
-    OffPolicySolver(;π=PolicyParams(π=π, π_explore=π_explore, π⁻=deepcopy(π)), 
+    OffPolicySolver(;agent=PolicyParams(π=π, π_explore=π_explore, π⁻=deepcopy(π)), 
                      ΔN=ΔN,
                      𝒫=(π_smooth=π_smooth,),
                      log=LoggerParams(;dir = "log/ddpg", log...),

--- a/src/model_free/rl/dqn.jl
+++ b/src/model_free/rl/dqn.jl
@@ -1,13 +1,25 @@
-DQN_target(π, 𝒫, 𝒟, γ::Float32; kwargs...) = 𝒟[:r] .+ γ .* (1.f0 .- 𝒟[:done]) .* maximum(value(π, 𝒟[:sp]), dims=1)
+function DQN_target(π, 𝒫, 𝒟, γ::Float32; kwargs...)
+        𝒟[:r] .+ γ .* (1.f0 .- 𝒟[:done]) .* maximum(value(π, 𝒟[:sp]), dims=1)
+end
 
-DQN(;π::DiscreteNetwork, N::Int, ΔN=4, π_explore=ϵGreedyPolicy(LinearDecaySchedule(1., 0.1, floor(Int, N/2)), π.outputs), c_opt::NamedTuple=(;), log::NamedTuple=(;), kwargs...) = 
-        OffPolicySolver(;
-                π=π, 
-                log=LoggerParams(;dir="log/dqn", log...),
-                N=N,
-                ΔN=ΔN,
-                c_opt = TrainingParams(;loss=td_loss, name="critic_", epochs=ΔN, c_opt...),
-                target_fn=DQN_target,
-                π_explore=π_explore,
-                kwargs...)
+function DQN(;π::DiscreteNetwork, 
+              N::Int, 
+              ΔN=4, 
+              π_explore=ϵGreedyPolicy(LinearDecaySchedule(1., 0.1, floor(Int, N/2)), π.outputs), 
+              c_opt::NamedTuple=(;), 
+              log::NamedTuple=(;),
+              c_loss=td_loss(),
+              target_fn=DQN_target,
+              prefix="",
+              kwargs...)
+              
+     OffPolicySolver(;π=PolicyParams(π=π, π_explore=π_explore, π⁻=deepcopy(π)), 
+                      log=LoggerParams(;dir="log/dqn", log...),
+                      N=N,
+                      ΔN=ΔN,
+                      c_opt = TrainingParams(;loss=c_loss, name=string(prefix, "critic_"), epochs=ΔN, c_opt...),
+                      target_fn=target_fn,
+                      kwargs...)
+end 
+        
 

--- a/src/model_free/rl/dqn.jl
+++ b/src/model_free/rl/dqn.jl
@@ -13,7 +13,7 @@ function DQN(;π::DiscreteNetwork,
               prefix="",
               kwargs...)
               
-     OffPolicySolver(;π=PolicyParams(π=π, π_explore=π_explore, π⁻=deepcopy(π)), 
+     OffPolicySolver(;agent=PolicyParams(π=π, π_explore=π_explore, π⁻=deepcopy(π)), 
                       log=LoggerParams(;dir="log/dqn", log...),
                       N=N,
                       ΔN=ΔN,

--- a/src/model_free/rl/ppo.jl
+++ b/src/model_free/rl/ppo.jl
@@ -25,7 +25,7 @@ function PPO(;π::ActorCritic,
      log::NamedTuple=(;), 
      kwargs...)
      
-     OnPolicySolver(;π=PolicyParams(π),
+     OnPolicySolver(;agent=PolicyParams(π),
                     𝒫=(ϵ=ϵ, λp=λp, λe=λe),
                     log = LoggerParams(;dir = "log/ppo", log...),
                     a_opt = TrainingParams(;loss = ppo_loss, early_stopping = (infos) -> (infos[end][:kl] > 0.015), name = "actor_", a_opt...),

--- a/src/model_free/rl/ppo.jl
+++ b/src/model_free/rl/ppo.jl
@@ -16,15 +16,24 @@ function ppo_loss(π, 𝒫, 𝒟; info = Dict())
     𝒫[:λp]*p_loss + 𝒫[:λe]*e_loss
 end
 
-PPO(;π::ActorCritic, ϵ::Float32 = 0.2f0, λp::Float32 = 1f0, λe::Float32 = 0.1f0, a_opt::NamedTuple=(;), c_opt::NamedTuple=(;), log::NamedTuple=(;), kwargs...) = 
-    OnPolicySolver(;
-        π = π,
-        𝒫=(ϵ=ϵ, λp=λp, λe=λe),
-        log = LoggerParams(;dir = "log/ppo", log...),
-        a_opt = TrainingParams(;loss = ppo_loss, early_stopping = (infos) -> (infos[end][:kl] > 0.015), name = "actor_", a_opt...),
-        c_opt = TrainingParams(;loss = (π, 𝒫, D; kwargs...) -> Flux.mse(value(π, D[:s]), D[:return]), name = "critic_", c_opt...),
-        post_batch_callback = (𝒟; kwargs...) -> (𝒟[:advantage] .= whiten(𝒟[:advantage])),
-        kwargs...)
+function PPO(;π::ActorCritic, 
+     ϵ::Float32 = 0.2f0, 
+     λp::Float32 = 1f0, 
+     λe::Float32 = 0.1f0, 
+     a_opt::NamedTuple=(;), 
+     c_opt::NamedTuple=(;), 
+     log::NamedTuple=(;), 
+     kwargs...)
+     
+     OnPolicySolver(;π=PolicyParams(π),
+                    𝒫=(ϵ=ϵ, λp=λp, λe=λe),
+                    log = LoggerParams(;dir = "log/ppo", log...),
+                    a_opt = TrainingParams(;loss = ppo_loss, early_stopping = (infos) -> (infos[end][:kl] > 0.015), name = "actor_", a_opt...),
+                    c_opt = TrainingParams(;loss = (π, 𝒫, D; kwargs...) -> Flux.mse(value(π, D[:s]), D[:return]), name = "critic_", c_opt...),
+                    post_batch_callback = (𝒟; kwargs...) -> (𝒟[:advantage] .= whiten(𝒟[:advantage])),
+                    kwargs...)
+end
+        
     
 
 

--- a/src/model_free/rl/reinforce.jl
+++ b/src/model_free/rl/reinforce.jl
@@ -16,7 +16,7 @@ function REINFORCE(;π,
                     log::NamedTuple=(;), 
                     kwargs...)
                     
-    OnPolicySolver(;π=PolicyParams(π),
+    OnPolicySolver(;agent=PolicyParams(π),
                     log = LoggerParams(;dir = "log/reinforce", log...),
                     a_opt = TrainingParams(;loss = reinforce_loss, early_stopping = (infos) -> (infos[end][:kl] > 0.015), name = "actor_", a_opt...),
                     kwargs...)

--- a/src/model_free/rl/reinforce.jl
+++ b/src/model_free/rl/reinforce.jl
@@ -11,11 +11,17 @@ function reinforce_loss(π, 𝒫, 𝒟; info = Dict())
 end
 
 # Build a REINFORCE solver
-REINFORCE(;a_opt::NamedTuple=(;), log::NamedTuple=(;), kwargs...) = 
-    OnPolicySolver(;
-        log = LoggerParams(;dir = "log/reinforce", log...),
-        a_opt = TrainingParams(;loss = reinforce_loss, early_stopping = (infos) -> (infos[end][:kl] > 0.015), name = "actor_", a_opt...),
-        kwargs...)
+function REINFORCE(;π,
+                    a_opt::NamedTuple=(;), 
+                    log::NamedTuple=(;), 
+                    kwargs...)
+                    
+    OnPolicySolver(;π=PolicyParams(π),
+                    log = LoggerParams(;dir = "log/reinforce", log...),
+                    a_opt = TrainingParams(;loss = reinforce_loss, early_stopping = (infos) -> (infos[end][:kl] > 0.015), name = "actor_", a_opt...),
+                    kwargs...)
+end
+        
     
 
 

--- a/src/model_free/rl/sac.jl
+++ b/src/model_free/rl/sac.jl
@@ -35,18 +35,32 @@ function SAC_temp_loss(π, 𝒫, 𝒟; info = Dict())
     -mean(exp(𝒫[:SAC_log_α][1]) .* target_α)
 end
 
-function SAC(;π::ActorCritic{T, DoubleNetwork{ContinuousNetwork, ContinuousNetwork}}, ΔN=50, SAC_α::Float32=1f0, SAC_H_target::Float32 = Float32(-prod(dim(action_space(π)))), π_explore=GaussianNoiseExplorationPolicy(0.1f0), SAC_α_opt::NamedTuple=(;), a_opt::NamedTuple=(;), c_opt::NamedTuple=(;), log::NamedTuple=(;), 𝒫::NamedTuple=(;), param_optimizers=Dict(), kwargs...) where T
-    𝒫 = (SAC_log_α = [Base.log(SAC_α)], SAC_H_target = SAC_H_target, 𝒫...)
-    OffPolicySolver(;
-        π = π,
-        ΔN=ΔN,
-        𝒫 = 𝒫,
-        log = LoggerParams(;dir = "log/sac", log...),
-        param_optimizers = Dict(Flux.params(𝒫[:SAC_log_α]) => TrainingParams(;loss=SAC_temp_loss, name="temp_", SAC_α_opt...), param_optimizers...),
-        a_opt = TrainingParams(;loss=SAC_actor_loss, name="actor_", a_opt...),
-        c_opt = TrainingParams(;loss=double_Q_loss, name="critic_", epochs=ΔN, c_opt...),
-        π_explore = π_explore,
-        target_fn = SAC_target(π),
-        kwargs...)
+function SAC(;π::ActorCritic{T, DoubleNetwork{ContinuousNetwork, ContinuousNetwork}}, 
+              ΔN=50, 
+              SAC_α::Float32=1f0, 
+              SAC_H_target::Float32 = Float32(-prod(dim(action_space(π)))), 
+              π_explore=GaussianNoiseExplorationPolicy(0.1f0), 
+              SAC_α_opt::NamedTuple=(;), 
+              a_opt::NamedTuple=(;), 
+              c_opt::NamedTuple=(;),
+              a_loss=SAC_actor_loss,
+              c_loss=double_Q_loss(),
+              target_fn=SAC_target(π),
+              prefix="",
+              log::NamedTuple=(;), 
+              𝒫::NamedTuple=(;), 
+              param_optimizers=Dict(), 
+              kwargs...) where T
+              
+    𝒫 = (SAC_log_α=[Base.log(SAC_α)], SAC_H_target=SAC_H_target, 𝒫...)
+    OffPolicySolver(;π=PolicyParams(π=π, π_explore=π_explore, π⁻=deepcopy(π)),
+                     ΔN=ΔN,
+                     𝒫=𝒫,
+                     log=LoggerParams(;dir = "log/sac", log...),
+                     param_optimizers=Dict(Flux.params(𝒫[:SAC_log_α]) => TrainingParams(;loss=SAC_temp_loss, name="temp_", SAC_α_opt...), param_optimizers...),
+                     a_opt=TrainingParams(;loss=a_loss, name=string(prefix, "actor_"), a_opt...),
+                     c_opt=TrainingParams(;loss=c_loss, name=string(prefix, "critic_"), epochs=ΔN, c_opt...),
+                     target_fn=target_fn,
+                     kwargs...)
 end
 

--- a/src/model_free/rl/sac.jl
+++ b/src/model_free/rl/sac.jl
@@ -53,7 +53,7 @@ function SAC(;π::ActorCritic{T, DoubleNetwork{ContinuousNetwork, ContinuousNetw
               kwargs...) where T
               
     𝒫 = (SAC_log_α=[Base.log(SAC_α)], SAC_H_target=SAC_H_target, 𝒫...)
-    OffPolicySolver(;π=PolicyParams(π=π, π_explore=π_explore, π⁻=deepcopy(π)),
+    OffPolicySolver(;agent=PolicyParams(π=π, π_explore=π_explore, π⁻=deepcopy(π)),
                      ΔN=ΔN,
                      𝒫=𝒫,
                      log=LoggerParams(;dir = "log/sac", log...),

--- a/src/model_free/rl/td3.jl
+++ b/src/model_free/rl/td3.jl
@@ -5,16 +5,28 @@ end
 
 TD3_actor_loss(π, 𝒫, 𝒟; info = Dict()) = -mean(value(π.C.N1, 𝒟[:s], action(π, 𝒟[:s])))
 
-TD3(;π::ActorCritic{A, C}, ΔN=50, 
-     π_smooth::Policy=GaussianNoiseExplorationPolicy(0.1f0, ϵ_min=-0.5f0, ϵ_max=0.5f0), π_explore=GaussianNoiseExplorationPolicy(0.1f0), a_opt::NamedTuple=(;), c_opt::NamedTuple=(;), log::NamedTuple=(;), 𝒫::NamedTuple=(;), kwargs...) where {A, C<:DoubleNetwork} = 
-    OffPolicySolver(;
-        π = π,
-        ΔN=ΔN,
-        𝒫=(π_smooth=π_smooth, 𝒫...),
-        log = LoggerParams(;dir = "log/td3", log...),
-        a_opt = TrainingParams(;loss=TD3_actor_loss, name="actor_", a_opt...),
-        c_opt = TrainingParams(;loss=double_Q_loss, name="critic_", epochs=ΔN, c_opt...),
-        π_explore = π_explore,
-        target_fn = TD3_target,
-        kwargs...)
+function TD3(;π::ActorCritic{A, C}, 
+              ΔN=50, 
+              π_smooth::Policy=GaussianNoiseExplorationPolicy(0.1f0, ϵ_min=-0.5f0, ϵ_max=0.5f0), 
+              π_explore=GaussianNoiseExplorationPolicy(0.1f0), 
+              a_opt::NamedTuple=(;), 
+              c_opt::NamedTuple=(;), 
+              a_loss=TD3_actor_loss,
+              c_loss=double_Q_loss(),
+              target_fn=TD3_target,
+              prefix="",
+              log::NamedTuple=(;), 
+              𝒫::NamedTuple=(;), 
+              kwargs...) where {A, C<:DoubleNetwork}
+     
+    OffPolicySolver(;π=PolicyParams(π=π, π_explore=π_explore, π⁻=deepcopy(π)),
+                     ΔN=ΔN,
+                     𝒫=(π_smooth=π_smooth, 𝒫...),
+                     log=LoggerParams(;dir = "log/td3", log...),
+                     a_opt=TrainingParams(;loss=a_loss, name=string(prefix, "actor_"), a_opt...),
+                     c_opt=TrainingParams(;loss=c_loss, name=string(prefix, "critic_"), epochs=ΔN, c_opt...),
+                     target_fn=target_fn,
+                     kwargs...)
+end
+        
 

--- a/src/model_free/rl/td3.jl
+++ b/src/model_free/rl/td3.jl
@@ -19,7 +19,7 @@ function TD3(;π::ActorCritic{A, C},
               𝒫::NamedTuple=(;), 
               kwargs...) where {A, C<:DoubleNetwork}
      
-    OffPolicySolver(;π=PolicyParams(π=π, π_explore=π_explore, π⁻=deepcopy(π)),
+    OffPolicySolver(;agent=PolicyParams(π=π, π_explore=π_explore, π⁻=deepcopy(π)),
                      ΔN=ΔN,
                      𝒫=(π_smooth=π_smooth, 𝒫...),
                      log=LoggerParams(;dir = "log/td3", log...),

--- a/src/spaces.jl
+++ b/src/spaces.jl
@@ -1,0 +1,43 @@
+abstract type AbstractSpace end
+@with_kw struct DiscreteSpace <: AbstractSpace
+    N::Int
+    vals = collect(1:N)
+end
+DiscreteSpace(N::Int) = DiscreteSpace(N = N)
+DiscreteSpace(vals::A) where {A <: AbstractArray} = DiscreteSpace(length(vals), vals)
+DiscreteSpace(vals::A) where {A <: Tuple} = DiscreteSpace(length(vals), vals)
+
+@with_kw struct ContinuousSpace{T <: Tuple} <: AbstractSpace 
+    dims::T
+    type::Type = Float32
+    μ = 0f0
+    σ = 1f0
+end
+ContinuousSpace(dims, type::Type=Float32; kwargs...) = ContinuousSpace(dims = tuple(dims...), type=type; kwargs...)
+
+type(S::DiscreteSpace) = Bool
+type(S::ContinuousSpace) = S.type
+
+dim(S::DiscreteSpace) = (S.N,)
+dim(S::ContinuousSpace) = S.dims
+
+tovec(v, S::DiscreteSpace) = Flux.onehot(v, S.vals)
+tovec(v, S::ContinuousSpace) = whiten(v, S.μ, S.σ)
+
+function state_space(o::AbstractArray; μ=0f0, σ=1f0)
+    dims = size(o)
+    length(dims) == 4 && dims[end] == 1 && (dims = dims[1:end-1]) # Handle image-like inputs that need to be 4D for conv layers
+    ContinuousSpace(dims, typeof(o[1]), μ, σ)
+end
+
+function state_space(mdp; μ=0f0, σ=1f0)
+    if mdp isa MDP
+        o = convert_s(AbstractArray, rand(initialstate(mdp)), mdp)
+    elseif mdp isa POMDP
+        s = rand(initialstate(mdp))
+        o = rand(initialobs(mdp, s))
+    else
+        error("Unrecognized problem: ", mdp)
+    end
+    return state_space(o, μ=μ, σ=σ)
+end

--- a/src/utils.jl
+++ b/src/utils.jl
@@ -3,6 +3,7 @@ struct ObjectCategorical
     cat::Categorical
     objs
     ObjectCategorical(objs::T) where {T <: AbstractArray} = new(Categorical(length(objs)), objs)
+    ObjectCategorical(objs::T) where {T <: Tuple} = new(Categorical(length(objs)), [objs...])
 end
 
 Base.rand(d::ObjectCategorical, sz::Int...) = d.objs[rand(d.cat, sz...)]
@@ -16,6 +17,16 @@ function Distributions.logpdf(d::ObjectCategorical, x)
     end
     
 end
+
+# Constant Layer
+struct ConstantLayer{T}
+    vec::T
+end
+
+Flux.@functor ConstantLayer
+(m::ConstantLayer)(x::AbstractArray) = m.vec
+
+
 
 ## Useful functions
 whiten(v) = whiten(v, mean(v), std(v))
@@ -55,7 +66,7 @@ end
 ## Losses
 function td_loss(;loss=Flux.mse, name=:Qavg, s_key=:s, a_key=:a, weight=nothing)
     (π, 𝒫, 𝒟, y; info=Dict()) -> begin
-        Q = value(π, 𝒟[skey], 𝒟[akey]) 
+        Q = value(π, 𝒟[s_key], 𝒟[a_key]) 
         
         # Store useful information
         ignore() do

--- a/test/devices_tests.jl
+++ b/test/devices_tests.jl
@@ -1,3 +1,4 @@
+using Crux, Flux
 ## Gpu stuff
 vcpu = zeros(Float32, 10, 10)
 vgpu = cu(zeros(Float32, 10, 10))

--- a/test/devices_tests.jl
+++ b/test/devices_tests.jl
@@ -1,0 +1,20 @@
+## Gpu stuff
+vcpu = zeros(Float32, 10, 10)
+vgpu = cu(zeros(Float32, 10, 10))
+@test Crux.device(vcpu) == cpu
+@test Crux.device(vgpu) == gpu
+@test Crux.device(view(vcpu,:,1)) == cpu
+@test Crux.device(view(vgpu,:,1)) == gpu
+
+c_cpu = Chain(Dense(5,2))
+c_gpu = Chain(Dense(5,2)) |> gpu
+@test Crux.device(c_cpu) == cpu
+@test Crux.device(c_gpu) == gpu
+
+@test Crux.device(mdcall(c_cpu, rand(5), cpu)) == cpu
+@test Crux.device(mdcall(c_gpu, rand(5), gpu)) == cpu
+@test Crux.device(mdcall(c_cpu, cu(rand(5)), cpu)) == gpu
+@test Crux.device(mdcall(c_gpu, cu(rand(5)), gpu)) == gpu
+
+v = zeros(4,4,4)
+@test size(bslice(v, 2)) == (4,4)

--- a/test/experience_buffer_tests.jl
+++ b/test/experience_buffer_tests.jl
@@ -120,6 +120,30 @@ circ_inds(start, Nsteps, l) = mod1.(start:start + Nsteps - 1, l)
 @test circ_inds(1, 120, 100) == [1:100 ..., 1:20 ...]
 @test circ_inds(90, 20, 100) == [90:100 ..., 1:9 ...]
 
+## Get last N indices test
+# A not full buffer
+b = ExperienceBuffer(ContinuousSpace(2), ContinuousSpace(1), 100)
+d = Dict(:s => 2*ones(2,50), :a => ones(Bool, 1,50), :sp => ones(2,50), :r => ones(1,50), :done => zeros(1,50), :weight=>zeros(1,50))
+push!(b, d)
+
+
+@test get_last_N_indices(b, 10) == collect(41:50)
+@test get_last_N_indices(b, 1) == [50]
+@test get_last_N_indices(b, 50) == collect(1:50)
+@test get_last_N_indices(b, 51) == collect(1:50)
+@test get_last_N_indices(b, 1000) == collect(1:50)
+
+# full buffer
+push!(b, d)
+push!(b, d)
+@test get_last_N_indices(b, 10) == collect(41:50)
+@test get_last_N_indices(b, 1) == [50]
+@test get_last_N_indices(b, 50) == collect(1:50)
+@test get_last_N_indices(b, 51) == [100, collect(1:50)...]
+@test get_last_N_indices(b, 100) == [collect(51:100)..., collect(1:50)...]
+@test get_last_N_indices(b, 1000) == [collect(51:100)..., collect(1:50)...]
+
+
 ## Priority Param Construction
 p = PriorityParams(100, α=0.7)
 @test length(p.minsort_priorities) == 100

--- a/test/extras_tests.jl
+++ b/test/extras_tests.jl
@@ -3,39 +3,6 @@ using Test
 using Zygote
 using Flux
 
-##  MultitaskDecay Schedule
-m = MultitaskDecaySchedule(10, [1,2,3])
-l = Crux.LinearDecaySchedule(1.0, 0.1, 10)
-
-for i=1:10
-    @test m(i) == l(i)
-end
-
-for i=11:20
-    @test m(i) == l(i-10)
-end
-
-for i=21:30
-    @test m(i) == l(i-20)
-end
-
-m = MultitaskDecaySchedule(10, [1,2,1])
-
-for i=1:10
-    @test m(i) == l(i)
-end
-
-for i=11:20
-    @test m(i) == l(i-10)
-end
-
-for i=21:30
-    @test m(i) == l(i-10)
-end
-
-@test m(31) == 0.1
-@test m(0) == 1
-
 ## gradient penalty
 m = Dense(2,1, init=ones, bias=false)
 x = ones(Float32, 2, 100)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,8 @@
 using CUDA, Crux
 CUDA.allowscalar(false)
 Crux.set_crux_warnings(false)
+include("spaces_tests.jl")
+include("devices_tests.jl")
 include("util_tests.jl")
 include("experience_buffer_tests.jl")
 include("sampler_tests.jl")

--- a/test/spaces_tests.jl
+++ b/test/spaces_tests.jl
@@ -1,0 +1,44 @@
+using Crux
+using Test
+using POMDPModels
+
+## Spaces
+mdp = SimpleGridWorld()
+
+s1 = DiscreteSpace(5)
+@test s1 isa AbstractSpace
+@test s1 isa DiscreteSpace
+@test s1.N == 5
+@test type(s1) == Bool
+@test Crux.dim(s1) == (5,)
+@test s1.vals == [1,2,3,4,5]
+@test tovec(4, s1) == Bool[0,0,0,1,0]
+
+s2 = DiscreteSpace(5, [:a, :b, :c, :d, :e])
+@test s2 isa AbstractSpace
+@test s2 isa DiscreteSpace
+@test s2.N == 5
+@test type(s2) == Bool
+@test Crux.dim(s2) == (5,)
+@test s2.vals == [:a, :b, :c, :d, :e]
+@test tovec(:d, s2) == Bool[0,0,0,1,0]
+
+s3 = ContinuousSpace((3,4), Float64)
+@test s3 isa AbstractSpace
+@test s3 isa ContinuousSpace
+@test s3.dims == (3,4)
+@test type(s3) == Float64
+@test Crux.dim(s3) == (3,4)
+@test tovec(zeros(3,4), s3) == zeros(3, 4)
+
+s3 = ContinuousSpace((3,4), Float64, 1f0, 2f0)
+@test s3 isa AbstractSpace
+@test s3 isa ContinuousSpace
+@test s3.dims == (3,4)
+@test type(s3) == Float64
+@test Crux.dim(s3) == (3,4)
+@test tovec(zeros(3,4),s3) == -0.5*ones(3, 4)
+
+s4 = state_space(mdp)
+@test s4 isa ContinuousSpace
+@test Crux.dim(s4) == (2,)

--- a/test/util_tests.jl
+++ b/test/util_tests.jl
@@ -4,68 +4,20 @@ using POMDPModels
 using Flux
 using LinearAlgebra
 using CUDA
+using Distributions
 
-## Spaces
-mdp = SimpleGridWorld()
+# Distribution stuff
+objs = [:up, :down]
+o = ObjectCategorical(objs)
+@test o.objs == objs
+@test o.cat.p == Categorical(2).p
 
-s1 = DiscreteSpace(5)
-@test s1 isa AbstractSpace
-@test s1 isa DiscreteSpace
-@test s1.N == 5
-@test type(s1) == Bool
-@test Crux.dim(s1) == (5,)
-@test s1.vals == [1,2,3,4,5]
-@test tovec(4, s1) == Bool[0,0,0,1,0]
 
-s2 = DiscreteSpace(5, [:a, :b, :c, :d, :e])
-@test s2 isa AbstractSpace
-@test s2 isa DiscreteSpace
-@test s2.N == 5
-@test type(s2) == Bool
-@test Crux.dim(s2) == (5,)
-@test s2.vals == [:a, :b, :c, :d, :e]
-@test tovec(:d, s2) == Bool[0,0,0,1,0]
+@test rand(o) in objs
+@test size(rand(o, 10)) == (10,)
 
-s3 = ContinuousSpace((3,4), Float64)
-@test s3 isa AbstractSpace
-@test s3 isa ContinuousSpace
-@test s3.dims == (3,4)
-@test type(s3) == Float64
-@test Crux.dim(s3) == (3,4)
-@test tovec(zeros(3,4), s3) == zeros(3, 4)
-
-s3 = ContinuousSpace((3,4), Float64, 1f0, 2f0)
-@test s3 isa AbstractSpace
-@test s3 isa ContinuousSpace
-@test s3.dims == (3,4)
-@test type(s3) == Float64
-@test Crux.dim(s3) == (3,4)
-@test tovec(zeros(3,4),s3) == -0.5*ones(3, 4)
-
-s4 = state_space(mdp)
-@test s4 isa ContinuousSpace
-@test Crux.dim(s4) == (2,)
-
-## Gpu stuff
-vcpu = zeros(Float32, 10, 10)
-vgpu = cu(zeros(Float32, 10, 10))
-@test Crux.device(vcpu) == cpu
-@test Crux.device(vgpu) == gpu
-@test Crux.device(view(vcpu,:,1)) == cpu
-@test Crux.device(view(vgpu,:,1)) == gpu
-
-c_cpu = Chain(Dense(5,2))
-c_gpu = Chain(Dense(5,2)) |> gpu
-@test Crux.device(c_cpu) == cpu
-@test Crux.device(c_gpu) == gpu
-
-@test Crux.device(mdcall(c_cpu, rand(5), cpu)) == cpu
-@test Crux.device(mdcall(c_gpu, rand(5), gpu)) == cpu
-@test Crux.device(mdcall(c_cpu, cu(rand(5)), cpu)) == gpu
-@test Crux.device(mdcall(c_gpu, cu(rand(5)), gpu)) == gpu
-
-v = zeros(4,4,4)
-@test size(bslice(v, 2)) == (4,4)
+@test logpdf(o, :up) == logpdf(o, :down)
+@test size(logpdf(o, rand(o,10))) == (1,10)
 
 ## Flux Stuff
 W = rand(2, 5)
@@ -82,6 +34,39 @@ grads = Flux.gradient(() -> loss(x, y), θ)
 
 @test norm(grads) > 1
 
+
+##  MultitaskDecay Schedule
+m = MultitaskDecaySchedule(10, [1,2,3])
+l = Crux.LinearDecaySchedule(1.0, 0.1, 10)
+
+for i=1:10
+    @test m(i) == l(i)
+end
+
+for i=11:20
+    @test m(i) == l(i-10)
+end
+
+for i=21:30
+    @test m(i) == l(i-20)
+end
+
+m = MultitaskDecaySchedule(10, [1,2,1])
+
+for i=1:10
+    @test m(i) == l(i)
+end
+
+for i=11:20
+    @test m(i) == l(i-10)
+end
+
+for i=21:30
+    @test m(i) == l(i-10)
+end
+
+@test m(31) == 0.1
+@test m(0) == 1
 
 
 

--- a/test/util_tests.jl
+++ b/test/util_tests.jl
@@ -6,6 +6,16 @@ using LinearAlgebra
 using CUDA
 using Distributions
 
+# Constant Layer
+c1 = ConstantLayer(ones(10))
+@test Crux.device(c1) == cpu
+@test c1(rand(100)) == c1.vec
+@test Flux.params(c1)[1] == c1.vec
+
+c2 = c1 |> gpu
+@test Crux.device(c2) == gpu
+@test c2(rand(100)) == c2.vec
+
 # Distribution stuff
 objs = [:up, :down]
 o = ObjectCategorical(objs)


### PR DESCRIPTION
This change abstracts the policy, the exploration policy, and the action space into the PolicyParams struct. This facilitates the addition of other policies such as an adversary. Also completed several consolidation tasks such as such as adding a constant layer for flux, merging epsilon-greedy into the mixed policy and integrating ASAF with OnPolicySovler