### PR TITLE
Cl il updates

### DIFF
--- a/src/Crux.jl
+++ b/src/Crux.jl
@@ -22,6 +22,7 @@ module Crux
     import Images: save
     using Statistics
     using Base.Iterators: partition
+    using WeightsAndBiasLogger
     
     extra_functions = Dict()
     function set_function(key, val)

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -12,7 +12,8 @@ end
     use_wandb::Bool = false
     config::Union{Dict, Nothing} = nothing
     project::Union{AbstractString, Nothing} = nothing
-    logger::Union{TBLogger, WBLogger} = use_wandb ? WBLogger(name=dir, config=config, project=project) : TBLogger(dir, tb_increment)
+    entity::Union{AbstractString, Nothing} = nothing
+    logger::Union{TBLogger, WBLogger} = use_wandb ? WBLogger(name=dir, config=config, project=project, entity=entity) : TBLogger(dir, tb_increment)
     fns = Any[log_undiscounted_return(10)]
     verbose::Bool = true
     sampler::Union{Sampler, Nothing, Vector} = nothing

--- a/src/logging.jl
+++ b/src/logging.jl
@@ -1,10 +1,18 @@
 elapsed(i::Int, N::Int) = (i % N) == 0
 elapsed(i::UnitRange, N::Int) = any([i...] .% N .== 0)
 
+function log_value(logger::WBLogger, name::AbstractString, value::Real; step=0)
+    info_dict = Dict(string(name) => value)
+    wandb.log(info_dict, step=step)
+end
+
 @with_kw mutable struct LoggerParams
     dir::String = "log/"
     period::Int64 = 500
-    logger = TBLogger(dir, tb_increment)
+    use_wandb::Bool = false
+    config::Union{Dict, Nothing} = nothing
+    project::Union{AbstractString, Nothing} = nothing
+    logger::Union{TBLogger, WBLogger} = use_wandb ? WBLogger(name=dir, config=config, project=project) : TBLogger(dir, tb_increment)
     fns = Any[log_undiscounted_return(10)]
     verbose::Bool = true
     sampler::Union{Sampler, Nothing, Vector} = nothing


### PR DESCRIPTION
Added in initial draft of weights and biases support, with basic logging. 
Can definitely be cleaned up quite a bit. 
In particular, would be cleaner to have arbitrary wandb keyword support for the wandb constructor, 
but I'm not quite sure how to do that. 