### PR TITLE
Adding Soft Q-Learning and IQLearn

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Supports CPU and GPU computation and implements the following algorithms:
 ### Reinforcement Learning
 * <a href="./src/model_free/rl/dqn.jl">Deep Q-Learning</a>
   * Prioritized Experience Replay
+* <a href="./src/model_free/rl/softq.jl">Soft Q-Learning</a>
 * <a href="./src/model_free/rl/reinforce.jl">REINFORCE</a>
 * <a href="./src/model_free/rl/ppo.jl">Proximal Policy Optimization (PPO)</a>
 * Lagrange-Constrained PPO
@@ -24,6 +25,7 @@ Supports CPU and GPU computation and implements the following algorithms:
 * <a href="./src/model_free/il/AdRIL.jl">(AdRIL)</a>
 * <a href="./src/model_free/il/sqil.jl">(SQIL)</a>
 * <a href="./src/model_free/il/asaf.jl">Adversarial Soft Advantage Fitting (ASAF)</a>
+* <a href="./src/model_free/il/iqlearn.jl">Inverse Q-Learning (IQLearn)</a>
 
 ### Batch RL
 * <a href="./src/model_free/batch/sac.jl">Batch Soft Actor Critic (SAC)</a>

--- a/examples/il/cartpole.jl
+++ b/examples/il/cartpole.jl
@@ -9,7 +9,6 @@ S = state_space(mdp)
 Disc() = ContinuousNetwork(Chain(Dense(6, 64, relu), Dense(64, 64, relu), Dense(64, 1)))
 V() = ContinuousNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, 1)))
 A() = DiscreteNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, length(as))), as)
-SA() = SoftDiscreteNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, length(as))), as;α=Float32(1.))
 
 # Fill a buffer with expert trajectories
 expert_trajectories = BSON.load("examples/il/expert_data/cartpole.bson")[:data]
@@ -24,7 +23,7 @@ solve(𝒮_gail, mdp)
 solve(𝒮_bc, mdp)
 
 # Solve with IQ-Learn
-𝒮_iql = OnlineIQLearn(π=SA(), 𝒟_demo=expert_trajectories, S=S, γ=γ, N=10000, ΔN=1, 
+𝒮_iql = OnlineIQLearn(π=A(), 𝒟_demo=expert_trajectories, S=S, γ=γ, N=10000, ΔN=1, 
     c_opt=(;epochs=1),reg=false,gp=false, log=(;period=50))
 solve(𝒮_iql, mdp)
 

--- a/examples/il/cartpole.jl
+++ b/examples/il/cartpole.jl
@@ -18,13 +18,19 @@ SA() = SoftDiscreteNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(
 expert_trajectories = BSON.load("examples/il/expert_data/cartpole.bson")[:data]
 
 # Solve with PPO-GAIL
-#𝒮_gail = OnPolicyGAIL(D=Disc(), γ=γ, gan_loss=GAN_BCELoss(), 𝒟_demo=expert_trajectories, solver=PPO, π=ActorCritic(A(), V()), S=S, N=40000, ΔN=1024, d_opt=(batch_size=1024, epochs=80))
-#solve(𝒮_gail, mdp)
+𝒮_gail = OnPolicyGAIL(D=Disc(), γ=γ, gan_loss=GAN_BCELoss(), 𝒟_demo=expert_trajectories, solver=PPO, π=ActorCritic(A(), V()), S=S, 
+    N=40000, ΔN=1024, d_opt=(batch_size=1024, epochs=80))
+solve(𝒮_gail, mdp)
 
 # Solve with Behavioral Cloning
-#𝒮_bc = BC(π=A(), 𝒟_demo=expert_trajectories, S=S, opt=(epochs=100,), log=(period=10,))
-#N = solve(𝒮_bc, mdp)
+𝒮_bc = BC(π=A(), 𝒟_demo=expert_trajectories, S=S, opt=(epochs=100,), log=(period=10,))
+solve(𝒮_bc, mdp)
 
 # Solve with IQ-Learn
-𝒮_iql = OnlineIQLearn(π=SA(), 𝒟_demo=expert_trajectories, S=S, γ=γ, N=40000, ΔN=1024)
+𝒮_iql = OnlineIQLearn(π=SA(), 𝒟_demo=expert_trajectories, S=S, γ=γ, N=40000, ΔN=200, log=(;period=50))
 solve(𝒮_iql, mdp)
+
+# Plot true rewards
+p = plot_learning([𝒮_gail, 𝒮_bc, 𝒮_iql], title = "CartPole-V0 Imitation Training Curves", 
+    labels = ["GAIL", "BC", "IQLearn"])
+Crux.savefig(p, "examples/il/cartpole_training.pdf")

--- a/examples/il/cartpole.jl
+++ b/examples/il/cartpole.jl
@@ -1,9 +1,12 @@
+using Debugger, Revise #remove
 using Crux, Flux, POMDPGym, Random, POMDPs, BSON
+
 
 ## Cartpole
 mdp = GymPOMDP(:CartPole, version = :v0)
 as = actions(mdp)
 S = state_space(mdp)
+γ = Float32(discount(mdp))
 
 Disc() = ContinuousNetwork(Chain(Dense(6, 64, relu), Dense(64, 64, relu), Dense(64, 1)))
 V() = ContinuousNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, 1)))
@@ -15,14 +18,13 @@ SA() = SoftDiscreteNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(
 expert_trajectories = BSON.load("examples/il/expert_data/cartpole.bson")[:data]
 
 # Solve with PPO-GAIL
-γ = Float32(discount(mdp))
-𝒮_gail = OnPolicyGAIL(D=Disc(), γ=γ, gan_loss=GAN_BCELoss(), 𝒟_demo=expert_trajectories, solver=PPO, π=ActorCritic(A(), V()), S=S, N=40000, ΔN=1024, d_opt=(batch_size=1024, epochs=80))
-solve(𝒮_gail, mdp)
+#𝒮_gail = OnPolicyGAIL(D=Disc(), γ=γ, gan_loss=GAN_BCELoss(), 𝒟_demo=expert_trajectories, solver=PPO, π=ActorCritic(A(), V()), S=S, N=40000, ΔN=1024, d_opt=(batch_size=1024, epochs=80))
+#solve(𝒮_gail, mdp)
 
 # Solve with Behavioral Cloning
-𝒮_bc = BC(π=A(), 𝒟_demo=expert_trajectories, S=S, opt=(epochs=100,), log=(period=10,))
-N = solve(𝒮_bc, mdp)
+#𝒮_bc = BC(π=A(), 𝒟_demo=expert_trajectories, S=S, opt=(epochs=100,), log=(period=10,))
+#N = solve(𝒮_bc, mdp)
 
 # Solve with IQ-Learn
-𝒮_iql = IQLearn(π=SA(), 𝒟_demo=expert_trajectories, S=S)
+𝒮_iql = OnlineIQLearn(π=SA(), 𝒟_demo=expert_trajectories, S=S, γ=γ, N=40000, ΔN=1024)
 solve(𝒮_iql, mdp)

--- a/examples/il/cartpole.jl
+++ b/examples/il/cartpole.jl
@@ -21,3 +21,4 @@ solve(𝒮_gail, mdp)
 𝒮_bc = BC(π=A(), 𝒟_demo=expert_trajectories, S=S, opt=(epochs=100,), log=(period=10,))
 N = solve(𝒮_bc, mdp)
 
+# Solve with IQ-Learn

--- a/examples/il/cartpole.jl
+++ b/examples/il/cartpole.jl
@@ -8,6 +8,8 @@ S = state_space(mdp)
 Disc() = ContinuousNetwork(Chain(Dense(6, 64, relu), Dense(64, 64, relu), Dense(64, 1)))
 V() = ContinuousNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, 1)))
 A() = DiscreteNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, length(as))), as)
+SA() = SoftDiscreteNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, length(as))), as;α=Float32(1.))
+
 
 # Fill a buffer with expert trajectories
 expert_trajectories = BSON.load("examples/il/expert_data/cartpole.bson")[:data]
@@ -22,3 +24,5 @@ solve(𝒮_gail, mdp)
 N = solve(𝒮_bc, mdp)
 
 # Solve with IQ-Learn
+𝒮_iql = IQLearn(π=SA(), 𝒟_demo=expert_trajectories, S=S)
+solve(𝒮_iql, mdp)

--- a/examples/il/cartpole.jl
+++ b/examples/il/cartpole.jl
@@ -10,7 +10,7 @@ V() = ContinuousNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64,
 A() = DiscreteNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, length(as))), as)
 
 # Fill a buffer with expert trajectories
-expert_trajectories = BSON.load("/Users/anthonycorso/.julia/dev/Crux/examples/il/expert_data/cartpole.bson")[:data]
+expert_trajectories = BSON.load("examples/il/expert_data/cartpole.bson")[:data]
 
 # Solve with PPO-GAIL
 γ = Float32(discount(mdp))

--- a/examples/il/cartpole.jl
+++ b/examples/il/cartpole.jl
@@ -1,6 +1,4 @@
-using Debugger, Revise #remove
 using Crux, Flux, POMDPGym, Random, POMDPs, BSON
-
 
 ## Cartpole
 mdp = GymPOMDP(:CartPole, version = :v0)
@@ -13,29 +11,8 @@ V() = ContinuousNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64,
 A() = DiscreteNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, length(as))), as)
 SA() = SoftDiscreteNetwork(Chain(Dense(4, 64, relu), Dense(64, 64, relu), Dense(64, length(as))), as;α=Float32(1.))
 
-
 # Fill a buffer with expert trajectories
 expert_trajectories = BSON.load("examples/il/expert_data/cartpole.bson")[:data]
-
-# IQLearn ΔN, c_opt epochs hyperparams
-mix = [(1,1),(1,5), (4,5), (4,10), (20,20), (20,50)]
-𝒮_iqls = [OnlineIQLearn(π=SA(), 𝒟_demo=expert_trajectories, S=S, γ=γ, N=10000, ΔN=dn, log=(;period=100), c_opt=(;epochs=e)) for (dn,e) in mix]
-[@time solve(i, mdp) for i in 𝒮_iqls]
-p = plot_learning(𝒮_iqls, title = "CartPole-V0 IQL Tradeoff Curves", 
-    labels = ["IQL ΔN=($dn),ep=($e)" for (dn,e) in mix])
-Crux.savefig(p, "examples/il/cartpole_iqlearn_dne_tradeoffs.pdf")
-
-# IQLearn λ_gp, α_reg hyperparams
-λ_gps = Float32[1, 0.1, 0.01, 0.]
-α_regs = Float32[100, 1, 0.1]
-mix = Iterators.product(λ_gps,α_regs)
-𝒮_iqls = [OnlineIQLearn(π=SA(), 𝒟_demo=expert_trajectories, 
-    S=S, γ=γ, λ_gp=i, α_reg=j, N=10000, ΔN=1, 
-    log=(;period=100), c_opt=(;epochs=1)) for (i,j) in mix]
-[@time solve(i, mdp) for i in 𝒮_iqls]
-p = plot_learning(𝒮_iqls, title = "CartPole-V0 IQL Tradeoff Curves", 
-    labels = ["IQL λ_gp=($i),α_reg=($j)" for (i,j) in mix])
-Crux.savefig(p, "examples/il/cartpole_iqlearn_reg_tradeoffs.pdf")
 
 # Solve with PPO-GAIL
 𝒮_gail = OnPolicyGAIL(D=Disc(), γ=γ, gan_loss=GAN_BCELoss(), 𝒟_demo=expert_trajectories, solver=PPO, π=ActorCritic(A(), V()), S=S, 
@@ -47,7 +24,8 @@ solve(𝒮_gail, mdp)
 solve(𝒮_bc, mdp)
 
 # Solve with IQ-Learn
-𝒮_iql = OnlineIQLearn(π=SA(), 𝒟_demo=expert_trajectories, S=S, γ=γ, N=40000, ΔN=200, log=(;period=50))
+𝒮_iql = OnlineIQLearn(π=SA(), 𝒟_demo=expert_trajectories, S=S, γ=γ, N=10000, ΔN=1, 
+    c_opt=(;epochs=1),reg=false,gp=false, log=(;period=50))
 solve(𝒮_iql, mdp)
 
 # Plot true rewards

--- a/examples/il/pendulum.jl
+++ b/examples/il/pendulum.jl
@@ -1,5 +1,5 @@
 using POMDPs, Crux, Flux, POMDPGym, BSON
-import POMDPPolicies:FunctionPolicy
+import POMDPTools:FunctionPolicy
 import Distributions:Uniform
 using Random
 using Distributions
@@ -14,7 +14,7 @@ rand_policy = FunctionPolicy((s) -> Float32.(rand.(Uniform.(amin, amax))))
 S = state_space(mdp)#, σ=[3.14f0, 8f0])
 
 # get expert trajectories
-expert_trajectories = BSON.load("/home/anthonycorso/.julia/dev/Crux/examples/il/expert_data/pendulum.bson")[:data]
+expert_trajectories = BSON.load("examples/il/expert_data/pendulum.bson")[:data]
 expert_perf = sum(expert_trajectories[:r]) / length(episodes(expert_trajectories))
 expert_trajectories[:r] .= 1
 

--- a/examples/rl/cartpole.jl
+++ b/examples/rl/cartpole.jl
@@ -9,6 +9,17 @@ A() = DiscreteNetwork(Chain(Dense(Crux.dim(S)..., 64, relu), Dense(64, 64, relu)
 V() = ContinuousNetwork(Chain(Dense(Crux.dim(S)..., 64, relu), Dense(64, 64, relu), Dense(64, 1)))
 SoftA(α::Float32) = SoftDiscreteNetwork(Chain(Dense(Crux.dim(S)..., 64, relu), Dense(64, 64, relu), Dense(64, length(as))), as;α=α)
 
+# collection and c_opt_epoch optimization
+ΔNs=[1,2,4]
+epochs = [1,5,10,50]
+mix = Iterators.product(ΔNs,epochs)  
+𝒮_sqls_2 = [SoftQ(π=SoftA(Float32(0.5)), S=S, N=10000, 
+    ΔN=dn, c_opt=(;epochs=e), interaction_storage=[]) for (dn,e) in mix]
+π_sqls_2 = [@time solve(x, mdp) for x in 𝒮_sqls_2]
+p = plot_learning(𝒮_sqls_2, title = "CartPole-V0 SoftQ Tradeoff Curves", 
+    labels = ["SQL ΔN=($dn),ep=($e)" for (dn,e) in mix])
+Crux.savefig(p, "examples/rl/cartpole_soft_q_tradeoffs.pdf")
+
 
 # Solve with REINFORCE (~2 seconds)
 𝒮_reinforce = REINFORCE(π=A(), S=S, N=10000, ΔN=500, a_opt=(epochs=5,), interaction_storage=[])
@@ -38,6 +49,11 @@ Crux.savefig(p, "examples/rl/cartpole_training.pdf")
 
 # Produce a gif with the final policy
 gif(mdp, π_ppo, "cartpole_policy.gif", max_steps=100)
+
+
+
+
+
 
 ## Optional - Save data for imitation learning
 # using BSON

--- a/examples/rl/cartpole.jl
+++ b/examples/rl/cartpole.jl
@@ -7,7 +7,6 @@ S = state_space(mdp)
 
 A() = DiscreteNetwork(Chain(Dense(Crux.dim(S)..., 64, relu), Dense(64, 64, relu), Dense(64, length(as))), as)
 V() = ContinuousNetwork(Chain(Dense(Crux.dim(S)..., 64, relu), Dense(64, 64, relu), Dense(64, 1)))
-SoftA(α::Float32) = SoftDiscreteNetwork(Chain(Dense(Crux.dim(S)..., 64, relu), Dense(64, 64, relu), Dense(64, length(as))), as;α=α)
 
 # Solve with REINFORCE (~2 seconds)
 𝒮_reinforce = REINFORCE(π=A(), S=S, N=10000, ΔN=500, a_opt=(epochs=5,), interaction_storage=[])
@@ -26,7 +25,7 @@ SoftA(α::Float32) = SoftDiscreteNetwork(Chain(Dense(Crux.dim(S)..., 64, relu), 
 @time π_dqn = solve(𝒮_dqn, mdp)
 
 # Solve with SoftQLearning w/ varying α (~12 seconds)
-𝒮_sql = SoftQ(π=SoftA(Float32(0.1)), S=S, N=10000, 
+𝒮_sql = SoftQ(π=A(), α=Float32(0.1), S=S, N=10000, 
     ΔN=1, c_opt=(;epochs=5), interaction_storage=[])
 @time π_sql = solve(𝒮_sql, mdp)
 

--- a/examples/rl/cartpole.jl
+++ b/examples/rl/cartpole.jl
@@ -9,18 +9,6 @@ A() = DiscreteNetwork(Chain(Dense(Crux.dim(S)..., 64, relu), Dense(64, 64, relu)
 V() = ContinuousNetwork(Chain(Dense(Crux.dim(S)..., 64, relu), Dense(64, 64, relu), Dense(64, 1)))
 SoftA(α::Float32) = SoftDiscreteNetwork(Chain(Dense(Crux.dim(S)..., 64, relu), Dense(64, 64, relu), Dense(64, length(as))), as;α=α)
 
-# collection and c_opt_epoch optimization
-ΔNs=[1,2,4]
-epochs = [1,5,10,50]
-mix = Iterators.product(ΔNs,epochs)  
-𝒮_sqls_2 = [SoftQ(π=SoftA(Float32(0.5)), S=S, N=10000, 
-    ΔN=dn, c_opt=(;epochs=e), interaction_storage=[]) for (dn,e) in mix]
-π_sqls_2 = [@time solve(x, mdp) for x in 𝒮_sqls_2]
-p = plot_learning(𝒮_sqls_2, title = "CartPole-V0 SoftQ Tradeoff Curves", 
-    labels = ["SQL ΔN=($dn),ep=($e)" for (dn,e) in mix])
-Crux.savefig(p, "examples/rl/cartpole_soft_q_tradeoffs.pdf")
-
-
 # Solve with REINFORCE (~2 seconds)
 𝒮_reinforce = REINFORCE(π=A(), S=S, N=10000, ΔN=500, a_opt=(epochs=5,), interaction_storage=[])
 @time π_reinforce = solve(𝒮_reinforce, mdp)
@@ -38,26 +26,22 @@ Crux.savefig(p, "examples/rl/cartpole_soft_q_tradeoffs.pdf")
 @time π_dqn = solve(𝒮_dqn, mdp)
 
 # Solve with SoftQLearning w/ varying α (~12 seconds)
-αs = Vector{Float32}([1,0.5,0.2,0.1])
-𝒮_sqls = [SoftQ(π=SoftA(α), S=S, N=10000, interaction_storage=[]) for α in αs]
-π_sqls = [@time solve(𝒮_sqls[i], mdp) for i=1:length(αs)]
+𝒮_sql = SoftQ(π=SoftA(Float32(0.1)), S=S, N=10000, 
+    ΔN=1, c_opt=(;epochs=5), interaction_storage=[])
+@time π_sql = solve(𝒮_sql, mdp)
 
 # Plot the learning curve
-p = plot_learning([𝒮_reinforce, 𝒮_a2c, 𝒮_ppo, 𝒮_dqn, 𝒮_sqls...], title = "CartPole-V0 Training Curves", 
-    labels = ["REINFORCE", "A2C", "PPO", "DQN", ["SQL ($i)" for i in αs]...])
+p = plot_learning([𝒮_reinforce, 𝒮_a2c, 𝒮_ppo, 𝒮_dqn, 𝒮_sql], title = "CartPole-V0 Training Curves", 
+    labels = ["REINFORCE", "A2C", "PPO", "DQN", "SoftQ" ])
 Crux.savefig(p, "examples/rl/cartpole_training.pdf")
 
 # Produce a gif with the final policy
 gif(mdp, π_ppo, "cartpole_policy.gif", max_steps=100)
 
 
-
-
-
-
 ## Optional - Save data for imitation learning
 # using BSON
-# s = Sampler(mdp, 𝒮_dqn.π, max_steps=100, required_columns=[:t])
+# s = Sampler(mdp, 𝒮_dqn.agent, max_steps=100, required_columns=[:t])
 # 
 # data = steps!(s, Nsteps=10000)
 # sum(data[:r])/100

--- a/examples/rl/pendulum.jl
+++ b/examples/rl/pendulum.jl
@@ -15,7 +15,6 @@ S = state_space(mdp, σ=[3.14f0, 8f0])
 # Define the networks we will use
 QSA() = ContinuousNetwork(Chain(Dense(3, 64, relu), Dense(64, 64, relu), Dense(64, 1)))
 QS() = DiscreteNetwork(Chain(Dense(2, 64, relu), Dense(64, 64, relu), Dense(64, length(as))), as)
-SoftA(α::Float32) = SoftDiscreteNetwork(Chain(Dense(2, 64, relu), Dense(64, 64, relu), Dense(64, length(as))), as; α=α)
 V() = ContinuousNetwork(Chain(Dense(2, 64, relu), Dense(64, 64, relu), Dense(64, 1)))
 A() = ContinuousNetwork(Chain(Dense(2, 64, relu), Dense(64, 64, relu), Dense(64, 1, tanh), x -> 2f0 * x), 1)
 SG() = SquashedGaussianPolicy(ContinuousNetwork(Chain(Dense(2, 64, relu), Dense(64, 64, relu), Dense(64, 1))), zeros(Float32, 1), 2f0)
@@ -38,9 +37,8 @@ SG() = SquashedGaussianPolicy(ContinuousNetwork(Chain(Dense(2, 64, relu), Dense(
 @time π_dqn = solve(𝒮_dqn, mdp)
 
 # Solve with SoftQ
-αs = Vector{Float32}([0.3,1,3])
-𝒮_sqls = [SoftQ(π=SoftA(α), S=S, N=60000) for α in αs]
-π_sqls = [@time solve(𝒮_sqls[i], mdp) for i=1:length(αs)]
+𝒮_sql = SoftQ(π=QS(),α=Float32(0.5), S=S, N=60000) 
+@time π_sql = solve(𝒮_sql, mdp)
 
 
 off_policy = (S=S,
@@ -65,8 +63,8 @@ off_policy = (S=S,
 @time π_sac = solve(𝒮_sac, mdp)
 
 # Plot the learning curve
-p = plot_learning([𝒮_reinforce, 𝒮_a2c, 𝒮_ppo, 𝒮_dqn, 𝒮_sqls..., 𝒮_ddpg, 𝒮_td3, 𝒮_sac], title="Pendulum Swingup Training Curves", 
-    labels=["REINFORCE", "A2C", "PPO", "DQN", ["SQL ($i)" for i in αs]..., "DDPG", "TD3", "SAC"], legend=:right)
+p = plot_learning([𝒮_reinforce, 𝒮_a2c, 𝒮_ppo, 𝒮_dqn, 𝒮_sql, 𝒮_ddpg, 𝒮_td3, 𝒮_sac], title="Pendulum Swingup Training Curves", 
+    labels=["REINFORCE", "A2C", "PPO", "DQN", "SoftQ", "DDPG", "TD3", "SAC"], legend=:right)
 Crux.savefig("examples/rl/pendulum_benchmark.pdf")
 
 # Produce a gif with the final policy

--- a/src/Crux.jl
+++ b/src/Crux.jl
@@ -108,17 +108,18 @@ module Crux
     include("model_free/off_policy.jl")
     include("model_free/batch.jl")
 
-    export REINFORCE, A2C, PPO, LagrangePPO, DQN, DDPG, TD3, SAC
+    export REINFORCE, A2C, PPO, LagrangePPO, DQN, DDPG, TD3, SoftQ, SAC
     include("model_free/rl/reinforce.jl")
     include("model_free/rl/a2c.jl")
     include("model_free/rl/ppo.jl")
     include("model_free/rl/dqn.jl")
     include("model_free/rl/ddpg.jl")
     include("model_free/rl/td3.jl")
+    include("model_free/rl/softq.jl")
     include("model_free/rl/sac.jl")
 
-    export OnPolicyGAIL, OffPolicyGAIL, BC, AdVIL, SQIL, AdRIL, ASAF
-    export mse_action_loss, logpdf_bc_loss, mse_value_loss, NDA_GAIL_JS
+    export OnPolicyGAIL, OffPolicyGAIL, BC, AdVIL, SQIL, AdRIL, ASAF, OnPolicyIQLearn
+    export mse_action_loss, logpdf_bc_loss, mse_value_loss, NDA_GAIL_JS, iq_loss
     include("model_free/il/bc.jl")
     include("model_free/il/AdVIL.jl")
     include("model_free/il/on_policy_gail.jl")
@@ -127,6 +128,7 @@ module Crux
     include("model_free/il/sqil.jl")
     include("model_free/il/AdRIL.jl")
     include("model_free/il/nda_gail_js.jl")
+    include("model_free/il/on_policy_iqlearn.jl")
 
     export CQL, BatchSAC
     include("model_free/batch/cql.jl")

--- a/src/Crux.jl
+++ b/src/Crux.jl
@@ -109,6 +109,7 @@ module Crux
     include("model_free/batch.jl")
 
     export REINFORCE, A2C, PPO, LagrangePPO, DQN, DDPG, TD3, SoftQ, SAC
+    export SoftDiscreteNetwork
     include("model_free/rl/reinforce.jl")
     include("model_free/rl/a2c.jl")
     include("model_free/rl/ppo.jl")

--- a/src/Crux.jl
+++ b/src/Crux.jl
@@ -24,6 +24,7 @@ module Crux
     using Base.Iterators: partition
     using WeightsAndBiasLogger
     using Dates
+    using Infiltrator # remove once done
 
     extra_functions = Dict()
     function set_function(key, val)
@@ -119,7 +120,7 @@ module Crux
     include("model_free/rl/softq.jl")
     include("model_free/rl/sac.jl")
 
-    export OnPolicyGAIL, OffPolicyGAIL, BC, AdVIL, SQIL, AdRIL, ASAF, OnPolicyIQLearn
+    export OnPolicyGAIL, OffPolicyGAIL, BC, AdVIL, SQIL, AdRIL, ASAF, OnlineIQLearn
     export mse_action_loss, logpdf_bc_loss, mse_value_loss, NDA_GAIL_JS, iq_loss
     include("model_free/il/bc.jl")
     include("model_free/il/AdVIL.jl")
@@ -129,7 +130,7 @@ module Crux
     include("model_free/il/sqil.jl")
     include("model_free/il/AdRIL.jl")
     include("model_free/il/nda_gail_js.jl")
-    include("model_free/il/on_policy_iqlearn.jl")
+    include("model_free/il/iqlearn.jl")
 
     export CQL, BatchSAC
     include("model_free/batch/cql.jl")

--- a/src/Crux.jl
+++ b/src/Crux.jl
@@ -24,8 +24,7 @@ module Crux
     using Base.Iterators: partition
     using WeightsAndBiasLogger
     using Dates
-    using Infiltrator # remove once done
-
+  
     extra_functions = Dict()
     function set_function(key, val)
         extra_functions[key] = val
@@ -110,7 +109,6 @@ module Crux
     include("model_free/batch.jl")
 
     export REINFORCE, A2C, PPO, LagrangePPO, DQN, DDPG, TD3, SoftQ, SAC
-    export SoftDiscreteNetwork
     include("model_free/rl/reinforce.jl")
     include("model_free/rl/a2c.jl")
     include("model_free/rl/ppo.jl")

--- a/src/experience_buffer.jl
+++ b/src/experience_buffer.jl
@@ -17,7 +17,7 @@ function mdp_data(S::T1, A::T2, capacity::Int, extras::Array{Symbol} = Symbol[];
         elseif k in [:weight, :importance_weight, :fwd_importance_weight,
                      :rev_importance_weight, :cum_importance_weight, :traj_importance_weight,]
             data[k] = ArrayType(fill(one(R), 1, capacity))
-        elseif k in [:fail, :grasp_success]
+        elseif k in [:fail, :grasp_success, :expert]
             data[k] = ArrayType(fill(false, 1, capacity))
         elseif k in [:t, :i, :id]
             data[k] = ArrayType(fill(0, 1, capacity))

--- a/src/model_free/il/iqlearn.jl
+++ b/src/model_free/il/iqlearn.jl
@@ -1,0 +1,98 @@
+# iqlearn off-policy, keep track of buffer that isnt thrown away 
+
+# concat 50% expert and 50% training batch
+# V, V' = getV(s), getV(s')
+# Q = Q(s,a)
+#
+# iq_loss(pi, Q, V, V') = 1) soft_q_loss + 2) value_loss
+#
+# y = (1-dones)*γ*V'
+# r = Q-y
+# 1) r_expert =r[expert_indices]
+# with no_grad(): phi_grad = f(r_expert) <- 1 for default
+# soft_q = -(phi_grad*r_expert).mean()
+#
+# online: 2) value_loss = (V-y).mean()
+# offline: 2) value_loss = (V-y)[expert_indices].mean()
+#
+# Other tricks to add to loss:
+# 
+# Grad penalty:
+# Interpolate between expert and demo states
+# compute 2-norm of jacobian of those interpolated states 
+# grad_penalty = lambda * ((gradients_norm - 1) ** 2).mean()
+# 
+# χ² divergence (offline):
+# chi2_loss = 1/(4α)* (r**2)[expert_indices].mean()
+#
+#
+# χ² regularization (online):
+# reg_loss = 1/(4α)* (r**2).mean()
+
+# actor lr = 3e-5
+# actor init temp = 
+# critic_target_update_frequency: 4
+# critic_lr: 1e-4
+# critic_betas: [0.9, 0.999]
+# init_temp: 0.01
+# critic_target_update_frequency: 4
+# critic_tau: 0.1
+# method
+# loss div: -
+# alpha: 0.5
+# lambda_gp: 10
+
+function IQ_loss(π, 𝒫, 𝒟, γ::Float32; kwargs...)
+    V = soft_value(π, 𝒟[:s])
+    Vp = soft_value(π, 𝒟[:sp])
+    Q = value(π, 𝒟[:s], onehotbatch(𝒟[:a]))
+    y = γ .* (1.f0 .- 𝒟[:done]) .* Vp
+    R = Q-y
+
+    p1 = mean(-R[expert])
+    p2 = mean(V-y)
+
+    loss = p1+p2
+    if gradient_penalty
+        gp = ...
+        loss += gp
+    end
+    if regularize
+        reg_loss = 1/(4*α) .* mean(R .^ 2)
+        loss += reg_loss
+    end
+    loss
+end
+
+function OnlineIQLearn(;π, 
+    S, 
+    𝒟_demo, 
+    normalize_demo::Bool=true, 
+    solver=SoftQ, # or SAC for continuous states 
+    d_opt::NamedTuple=(), 
+    log::NamedTuple=(;), 
+    regularize::Bool=true,
+    
+    kwargs...)
+
+    # Normalize and/or change device of expert and NDA data
+    dev = device(π)
+    A = action_space(π)
+    normalize_demo && (𝒟_demo = normalize!(deepcopy(𝒟_demo), S, A))
+    𝒟_demo = 𝒟_demo |> dev
+
+    # loss calculations
+    V = soft_value(s)
+    V' = soft_value(π,s')
+    a_oh = Flux.one_hot(a)
+    Q = value(π,s,a)
+    y = 
+
+    
+    function SoftQ_target(π, 𝒫, 𝒟, γ::Float32; kwargs...)
+        𝒟[:r] .+ γ .* (1.f0 .- 𝒟[:done]) .* soft_value(π, 𝒟[:sp])
+    end
+
+
+
+end

--- a/src/model_free/rl/softq.jl
+++ b/src/model_free/rl/softq.jl
@@ -87,7 +87,7 @@ end
 function SoftQ(;π::SoftDiscreteNetwork, 
           N::Int, 
           ΔN=4, 
-          c_opt::NamedTuple=(;), 
+          c_opt::NamedTuple=(;epochs=4), 
           log::NamedTuple=(;),
           c_loss=td_loss(),
           target_fn=SoftQ_target,
@@ -97,7 +97,7 @@ OffPolicySolver(;agent=PolicyParams(π=π, π⁻=deepcopy(π)),
                   log=LoggerParams(;dir="log/dqn", log...),
                   N=N,
                   ΔN=ΔN,
-                  c_opt = TrainingParams(;loss=c_loss, name=string(prefix, "critic_"), epochs=ΔN, c_opt...),
+                  c_opt = TrainingParams(;loss=c_loss, name=string(prefix, "critic_"), c_opt...),
                   target_fn=target_fn,
                   kwargs...)
 end 

--- a/src/model_free/rl/softq.jl
+++ b/src/model_free/rl/softq.jl
@@ -1,0 +1,112 @@
+# Soft-Q is technically on-policy, as the learned Q maps to the exploration policy. As such we have two options:
+# 1) use a DiscreteNetwork for the main policiy, and define our own wrapped exploration function for the exploration policy
+# 2) define a SoftDiscreteNetwork and use this for POMDPs.action() and exploration() [Preferred]
+# Will have to do something similar in the case of ContinuousNetwork for SoftActorCritic
+
+
+## Network for representing a discrete set of outputs (value or policy)
+# NOTE: Incoming actions (i.e. arguments) are all assumed to be one hot encoding. Outputs are discrete actions taken form outputs
+mutable struct SoftDiscreteNetwork <: NetworkPolicy
+    network
+    outputs
+    logit_conversion
+    alpha
+    always_stochastic
+    device
+    SoftDiscreteNetwork(network, outputs; logit_conversion=(π, s) -> softmax(value(π, s)), always_stochastic=false, dev=nothing) = new(network, cpu(outputs), logit_conversion, always_stochastic, device(network))
+    SoftDiscreteNetwork(network, outputs, logit_conversion, always_stochastic, dev) = new(network, cpu(outputs), logit_conversion, always_stochastic, device(network))
+end
+
+Flux.@functor SoftDiscreteNetwork
+
+Flux.trainable(π::SoftDiscreteNetwork) = Flux.trainable(π.network)
+
+layers(π::SoftDiscreteNetwork) = π.network.layers
+
+POMDPs.value(π::SoftDiscreteNetwork, s) = mdcall(π.network, s, π.device)
+
+POMDPs.value(π::SoftDiscreteNetwork, s, a_oh) = sum(value(π, s) .* a_oh, dims=1)
+
+POMDPs.action(π::SoftDiscreteNetwork, s) = π.always_stochastic ? exploration(π, s)[1] : π.outputs[mapslices(argmax, value(π, s), dims=1)]
+
+function Flux.onehotbatch(π::SoftDiscreteNetwork, a)
+    ignore_derivatives() do
+        a_oh = Flux.onehotbatch(a[:] |> cpu, π.outputs) |> device(a)
+        length(a) == 1 ? dropdims(a_oh, dims=2) : a_oh
+    end
+end
+
+logits(π::SoftDiscreteNetwork, s) = π.logit_conversion(π, s)
+
+categorical_logpdf(probs, a_oh) = log.(sum(probs .* a_oh, dims=1))
+
+function exploration(π::SoftDiscreteNetwork, s; kwargs...)
+    ps = logits(π, s)
+    ai = mapslices((v) -> rand(Categorical(v)), ps, dims=1)
+    a = π.outputs[ai]
+    a, categorical_logpdf(ps, Flux.onehotbatch(π, a))
+end
+
+function Distributions.logpdf(π::SoftDiscreteNetwork, s, a)
+    # If a does not seem to be a one-hot encoding then we encode it
+    ignore_derivatives() do
+        size(a, 1) == 1 && (a = Flux.onehotbatch(π, a))
+    end
+    return categorical_logpdf(logits(π, s), a)
+end
+
+function Distributions.entropy(π::SoftDiscreteNetwork, s)
+    ps = logits(π, s)
+    -sum(ps .* log.(ps .+ eps(Float32)), dims=1)
+end
+
+action_space(π::SoftDiscreteNetwork) = DiscreteSpace(length(π.outputs), π.outputs)
+
+
+
+
+########## 
+
+
+
+
+# since explore is on (offpolicysolver), can just define our own function 
+# a, log_probs = exploration(sampler.agent.π_explore, sampler.svec, π_on=sampler.agent.π, i=i)
+# exploration: action(s) propto softmax(q(s)/alpha) 
+
+
+soft_value(π, s; alpha::Float32=NaN32) = alpha .* logsumexp((value(π, s) ./ alpha), dims=1)
+
+# target = reward + (1-done)*gamma*v_target(sp)
+# v_target(sp) = alpha*logsumexp(q_target(sp)/alpha) 
+# update q(s, a) to target
+# v(s) = alpha*logsumexp(q(s)/alpha)
+function SoftQ_target(π, 𝒫, 𝒟, γ::Float32; alpha::Float32=NaN32, kwargs...)
+    𝒟[:r] .+ γ .* (1.f0 .- 𝒟[:done]) .* soft_value(π, 𝒟[:sp], alpha=alpha)
+end
+
+function SoftQ(;π::SoftDiscreteNetwork, 
+          N::Int, 
+          alpha::Real=0.5,
+          ΔN=4, 
+          c_opt::NamedTuple=(;), 
+          log::NamedTuple=(;),
+          c_loss=td_loss(),
+          target_fn=SoftQ_target,
+          prefix="",
+          kwargs...)
+
+          π_explore = ... 
+OffPolicySolver(;agent=PolicyParams(π=π, π_explore=π_explore, π⁻=deepcopy(π)), 
+                  log=LoggerParams(;dir="log/dqn", log...),
+                  N=N,
+                  ΔN=ΔN,
+                  c_opt = TrainingParams(;loss=c_loss, name=string(prefix, "critic_"), epochs=ΔN, c_opt...),
+                  target_fn=(π, 𝒫, 𝒟, γ::Float32; kwargs...) -> target_fn(π, 𝒫, 𝒟, γ;alpha=alpha, kwargs...),
+                  kwargs...)
+end 
+    
+
+
+
+


### PR DESCRIPTION
Adding simple Soft Q-Learning and Inverse Q-Learning (IQLearn) implementations, and adding examples to cartpole and (discrete) pendulum.

Note: this is only adding Online, discrete IQLearn. Offline requires implementing a few different regularizers. Continuous IQLearn is built off SAC and performs both actor and critic updates with IQ loss gradients